### PR TITLE
Deinit inspector session

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -104,7 +104,7 @@ v8::Platform* v8__Platform__NewDefaultPlatform(
         int thread_pool_size,
         bool idle_task_support) {
     return v8::platform::NewDefaultPlatform(
-        thread_pool_size,  
+        thread_pool_size,
         idle_task_support ? v8::platform::IdleTaskSupport::kEnabled : v8::platform::IdleTaskSupport::kDisabled,
         v8::platform::InProcessStackDumping::kDisabled,
         nullptr
@@ -1613,6 +1613,10 @@ void v8_inspector__Inspector__ContextCreated(v8_inspector::V8Inspector *self,
 }
 
 // InspectorSession
+
+void v8_inspector__Session__DELETE(v8_inspector::V8InspectorSession* self) {
+  delete self;
+}
 
 void v8_inspector__Session__dispatchProtocolMessage(
     v8_inspector::V8InspectorSession *session, v8::Isolate *isolate,

--- a/src/binding.h
+++ b/src/binding.h
@@ -298,7 +298,7 @@ bool v8__TryCatch__HasCaught(const TryCatch* self);
 const Value* v8__TryCatch__StackTrace(const TryCatch* self, const Context* context);
 bool v8__TryCatch__IsVerbose(const TryCatch* self);
 void v8__TryCatch__SetVerbose(
-    TryCatch* self, 
+    TryCatch* self,
     bool value);
 const Value* v8__TryCatch__ReThrow(TryCatch* self);
 
@@ -568,7 +568,7 @@ int64_t v8__Integer__Value(const Integer* self);
 
 // BigInt
 const BigInt* v8__BigInt__New(
-    Isolate* iso, 
+    Isolate* iso,
     int64_t val);
 const BigInt* v8__BigInt__NewFromUnsigned(
     Isolate* iso,
@@ -697,7 +697,7 @@ void v8__Function__SetName(const Function* self, const String* name);
 
 // External
 const External* v8__External__New(
-    Isolate* isolate, 
+    Isolate* isolate,
     void* value);
 void* v8__External__Value(
     const External* self);
@@ -992,6 +992,7 @@ const Context* v8_inspector__Client__IMPL__ensureDefaultContextInGroup(
 // InspectorSession
 
 typedef struct InspectorSession InspectorSession;
+void v8_inspector__Session__DELETE(Inspector *self);
 void v8_inspector__Session__dispatchProtocolMessage(InspectorSession *session, Isolate *isolate, const char* msg, usize msg_len);
 
 // Inspector

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -2632,6 +2632,10 @@ pub export fn v8_inspector__Channel__IMPL__flushProtocolNotifications(
 pub const InspectorSession = struct {
     handle: *c.InspectorSession,
 
+    pub fn deinit(self: InspectorSession) void {
+        c.v8_inspector__Session__DELETE(self.handle);
+    }
+
     pub fn dispatchProtocolMessage(
         self: InspectorSession,
         isolate: Isolate,


### PR DESCRIPTION
- add missing delete function for inspector session

`Inspector.Connect(..)` returns a unique_ptr from the C++ side so we need to take care to at least be able to clean it up.
In the future we may want the Inspector to "own" all sessions. For now the user is required to deinit the session.
Note that the suggested change would be a breaking change.