### PR TITLE
Remote object

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1550,6 +1550,13 @@ void v8__base__SetDcheckFunction(void (*func)(const char*, int, const char*)) {
 
 // Utils
 
+/// Header for Zig
+/// Allocates `bytes` bytes of memory using the allocator.
+/// @param allocator: A Zig std.mem.Allocator
+/// @param bytes: The number of bytes to allocate
+/// @returns A pointer to the allocated memory, null if allocation failed
+char* zigAlloc(void* allocator, uint64_t bytes);
+
 static inline v8_inspector::StringView toStringView(const char *str, size_t length) {
     auto* stringView = reinterpret_cast<const uint8_t*>(str);
     return { stringView, length };
@@ -1569,12 +1576,20 @@ static inline std::string fromStringView(v8::Isolate* isolate, const v8_inspecto
   return *result;
 }
 
-const char* toHeapCharPtr(const v8_inspector::String16& str) {
-    std::string utf8_str = str.utf8(); // Note that this may hold the string on the stack as an SSO
-    char* heap_str = new char[utf8_str.length() + 1];
+/// Allocates a string as utf8 on the heap, such that it can be returned to Zig.
+/// @param str: The string to return
+/// @param allocator: A Zig std.mem.Allocator
+/// @returns string pointer with null terminator, null if allocation failed
+const char* toHeapCharPtr(const v8_inspector::String16& str, void* allocator) {
+    std::string utf8_str = str.utf8(); // Note the data*'s lifetime is tied to utf8_str and this may hold the string data on the stack as an SSO, so we need to copy it onto the heap.
+    char* heap_str = zigAlloc(allocator, utf8_str.length() + 1); // +1 for null terminator, needed to communicate the length to Zig
+    if (heap_str == nullptr) {
+      return nullptr;
+    }
     strcpy(heap_str, utf8_str.c_str());
-    return heap_str;
-  }
+    return heap_str;   
+}
+
 
 // Inspector
 
@@ -1642,15 +1657,12 @@ v8_inspector::protocol::Runtime::RemoteObject* v8_inspector__Session__wrapObject
     const char *grpname, int grpname_len, bool generatepreview) {
   auto sv_grpname = toStringView(grpname, grpname_len);
   auto remote_object = session->wrapObject(ptr_to_local(ctx), ptr_to_local(val), sv_grpname, generatepreview);
-  assert(remote_object != nullptr);
-  auto* not_api = static_cast<v8_inspector::protocol::Runtime::RemoteObject*>(remote_object.release());
-  assert(not_api != nullptr);
-  return not_api;
+  return static_cast<v8_inspector::protocol::Runtime::RemoteObject*>(remote_object.release());
 }
 
 // RemoteObject
 
-// To prevent extra allocations on every call a single default value value is reused everytime.
+// To prevent extra allocations on every call a single default value is reused everytime.
 // It is expected that the precense of a value is checked before calling get* methods.
 const v8_inspector::String16 DEFAULT_STRING = {"default"};
 
@@ -1659,9 +1671,9 @@ void v8_inspector__RemoteObject__DELETE(v8_inspector::protocol::Runtime::RemoteO
 }
 
 // RemoteObject - Type
-const char* v8_inspector__RemoteObject__getType(v8_inspector::protocol::Runtime::RemoteObject* self) {
+const char* v8_inspector__RemoteObject__getType(v8_inspector::protocol::Runtime::RemoteObject* self, void* allocator) {
   auto str = self->getType();
-  return toHeapCharPtr(str);
+  return toHeapCharPtr(str, allocator);
 }
 void v8_inspector__RemoteObject__setType(v8_inspector::protocol::Runtime::RemoteObject* self, const char* type, int type_len) {
   self->setType(v8_inspector::String16::fromUTF8(type, type_len));
@@ -1671,9 +1683,9 @@ void v8_inspector__RemoteObject__setType(v8_inspector::protocol::Runtime::Remote
 bool v8_inspector__RemoteObject__hasSubtype(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasSubtype();
 }
-const char* v8_inspector__RemoteObject__getSubtype(v8_inspector::protocol::Runtime::RemoteObject* self) {
+const char* v8_inspector__RemoteObject__getSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, void* allocator) {
   auto str = self->getSubtype(DEFAULT_STRING);
-  return toHeapCharPtr(str);
+  return toHeapCharPtr(str, allocator);
 }
 void v8_inspector__RemoteObject__setSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, const char* subtype, int subtype_len) {
   self->setSubtype(v8_inspector::String16::fromUTF8(subtype, subtype_len));
@@ -1683,9 +1695,9 @@ void v8_inspector__RemoteObject__setSubtype(v8_inspector::protocol::Runtime::Rem
 bool v8_inspector__RemoteObject__hasClassName(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasClassName();
 }
-const char* v8_inspector__RemoteObject__getClassName(v8_inspector::protocol::Runtime::RemoteObject* self) {
+const char* v8_inspector__RemoteObject__getClassName(v8_inspector::protocol::Runtime::RemoteObject* self, void* allocator) {
   auto str = self->getClassName(DEFAULT_STRING);
-  return toHeapCharPtr(str);
+  return toHeapCharPtr(str, allocator);
 }
 void v8_inspector__RemoteObject__setClassName(v8_inspector::protocol::Runtime::RemoteObject* self, const char* className, int className_len) {
   self->setClassName(v8_inspector::String16::fromUTF8(className, className_len));
@@ -1706,9 +1718,9 @@ void v8_inspector__RemoteObject__setValue(v8_inspector::protocol::Runtime::Remot
 bool v8_inspector__RemoteObject__hasUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasUnserializableValue();
 }
-const char* v8_inspector__RemoteObject__getUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self) {
+const char* v8_inspector__RemoteObject__getUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, void* allocator) {
   auto str = self->getUnserializableValue(DEFAULT_STRING);
-  return toHeapCharPtr(str);
+  return toHeapCharPtr(str, allocator);
 }
 void v8_inspector__RemoteObject__setUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, const char* unserializableValue, int unserializableValue_len) {
   self->setUnserializableValue(v8_inspector::String16::fromUTF8(unserializableValue, unserializableValue_len));
@@ -1718,9 +1730,9 @@ void v8_inspector__RemoteObject__setUnserializableValue(v8_inspector::protocol::
 bool v8_inspector__RemoteObject__hasDescription(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasDescription();
 }
-const char* v8_inspector__RemoteObject__getDescription(v8_inspector::protocol::Runtime::RemoteObject* self) {
+const char* v8_inspector__RemoteObject__getDescription(v8_inspector::protocol::Runtime::RemoteObject* self, void* allocator) {
   auto str = self->getDescription(DEFAULT_STRING);
-  return toHeapCharPtr(str);
+  return toHeapCharPtr(str, allocator);
 }
 void v8_inspector__RemoteObject__setDescription(v8_inspector::protocol::Runtime::RemoteObject* self, const char* description, int description_len) {
   self->setDescription(v8_inspector::String16::fromUTF8(description, description_len));
@@ -1739,15 +1751,16 @@ void v8_inspector__RemoteObject__setWebDriverValue(v8_inspector::protocol::Runti
 
 // RemoteObject - ObjectId
 bool v8_inspector__RemoteObject__hasObjectId(v8_inspector::protocol::Runtime::RemoteObject* self) {
-    return self->hasObjectId();
-  }
-  const char* v8_inspector__RemoteObject__getObjectId(v8_inspector::protocol::Runtime::RemoteObject* self) {
-      auto str = self->getObjectId(DEFAULT_STRING);
-      return toHeapCharPtr(str);
-  }
+  return self->hasObjectId();
+}
+
+const char* v8_inspector__RemoteObject__getObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, void* allocator) {
+  auto str = self->getObjectId(DEFAULT_STRING);
+  return toHeapCharPtr(str, allocator);
+}
   void v8_inspector__RemoteObject__setObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, const char* objectId, int objectId_len) {
-    self->setObjectId(v8_inspector::String16::fromUTF8(objectId, objectId_len));
-  }
+  self->setObjectId(v8_inspector::String16::fromUTF8(objectId, objectId_len));
+}
 
 // RemoteObject - Preview
 bool v8_inspector__RemoteObject__hasPreview(v8_inspector::protocol::Runtime::RemoteObject* self) {

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1569,6 +1569,13 @@ static inline std::string fromStringView(v8::Isolate* isolate, const v8_inspecto
   return *result;
 }
 
+const char* toHeapCharPtr(const v8_inspector::String16& str) {
+    std::string utf8_str = str.utf8(); // Note that this may hold the string on the stack as an SSO
+    char* heap_str = new char[utf8_str.length() + 1];
+    strcpy(heap_str, utf8_str.c_str());
+    return heap_str;
+  }
+
 // Inspector
 
 v8_inspector::V8Inspector *v8_inspector__Inspector__Create(
@@ -1629,19 +1636,139 @@ void v8_inspector__Session__dispatchProtocolMessage(
   session->dispatchProtocolMessage(str_view);
 }
 
-v8_inspector::protocol::Runtime::API::RemoteObject* v8_inspector__Session__wrapObject(
+v8_inspector::protocol::Runtime::RemoteObject* v8_inspector__Session__wrapObject(
     v8_inspector::V8InspectorSession *session, v8::Isolate *isolate,
     const v8::Context* ctx, const v8::Value* val,
     const char *grpname, int grpname_len, bool generatepreview) {
   auto sv_grpname = toStringView(grpname, grpname_len);
   auto remote_object = session->wrapObject(ptr_to_local(ctx), ptr_to_local(val), sv_grpname, generatepreview);
-  return remote_object.release();
+  assert(remote_object != nullptr);
+  auto* not_api = static_cast<v8_inspector::protocol::Runtime::RemoteObject*>(remote_object.release());
+  assert(not_api != nullptr);
+  return not_api;
 }
 
 // RemoteObject
 
-void v8_inspector__RemoteObject__DELETE(v8_inspector::protocol::Runtime::API::RemoteObject* self) {
+// To prevent extra allocations on every call a single default value value is reused everytime.
+// It is expected that the precense of a value is checked before calling get* methods.
+const v8_inspector::String16 DEFAULT_STRING = {"default"};
+
+void v8_inspector__RemoteObject__DELETE(v8_inspector::protocol::Runtime::RemoteObject* self) {
   delete self;
+}
+
+// RemoteObject - Type
+const char* v8_inspector__RemoteObject__getType(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  auto str = self->getType();
+  return toHeapCharPtr(str);
+}
+void v8_inspector__RemoteObject__setType(v8_inspector::protocol::Runtime::RemoteObject* self, const char* type, int type_len) {
+  self->setType(v8_inspector::String16::fromUTF8(type, type_len));
+}
+
+// RemoteObject - Subtype
+bool v8_inspector__RemoteObject__hasSubtype(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  return self->hasSubtype();
+}
+const char* v8_inspector__RemoteObject__getSubtype(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  auto str = self->getSubtype(DEFAULT_STRING);
+  return toHeapCharPtr(str);
+}
+void v8_inspector__RemoteObject__setSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, const char* subtype, int subtype_len) {
+  self->setSubtype(v8_inspector::String16::fromUTF8(subtype, subtype_len));
+}
+
+// RemoteObject - ClassName
+bool v8_inspector__RemoteObject__hasClassName(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  return self->hasClassName();
+}
+const char* v8_inspector__RemoteObject__getClassName(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  auto str = self->getClassName(DEFAULT_STRING);
+  return toHeapCharPtr(str);
+}
+void v8_inspector__RemoteObject__setClassName(v8_inspector::protocol::Runtime::RemoteObject* self, const char* className, int className_len) {
+  self->setClassName(v8_inspector::String16::fromUTF8(className, className_len));
+}
+
+// RemoteObject - Value
+bool v8_inspector__RemoteObject__hasValue(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  return self->hasValue();
+}
+v8_inspector::protocol::Value* v8_inspector__RemoteObject__getValue(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  return self->getValue(nullptr);
+}
+void v8_inspector__RemoteObject__setValue(v8_inspector::protocol::Runtime::RemoteObject* self, v8_inspector::protocol::Value* value) {
+  self->setValue(std::unique_ptr<v8_inspector::protocol::Value>(value));
+}
+
+//RemoteObject - UnserializableValue
+bool v8_inspector__RemoteObject__hasUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  return self->hasUnserializableValue();
+}
+const char* v8_inspector__RemoteObject__getUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  auto str = self->getUnserializableValue(DEFAULT_STRING);
+  return toHeapCharPtr(str);
+}
+void v8_inspector__RemoteObject__setUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, const char* unserializableValue, int unserializableValue_len) {
+  self->setUnserializableValue(v8_inspector::String16::fromUTF8(unserializableValue, unserializableValue_len));
+}
+
+// RemoteObject - Description
+bool v8_inspector__RemoteObject__hasDescription(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  return self->hasDescription();
+}
+const char* v8_inspector__RemoteObject__getDescription(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  auto str = self->getDescription(DEFAULT_STRING);
+  return toHeapCharPtr(str);
+}
+void v8_inspector__RemoteObject__setDescription(v8_inspector::protocol::Runtime::RemoteObject* self, const char* description, int description_len) {
+  self->setDescription(v8_inspector::String16::fromUTF8(description, description_len));
+}
+
+// RemoteObject - WebDriverValue
+bool v8_inspector__RemoteObject__hasWebDriverValue(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  return self->hasWebDriverValue();
+}
+v8_inspector::protocol::Runtime::WebDriverValue* v8_inspector__RemoteObject__getWebDriverValue(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  return self->getWebDriverValue(nullptr);
+}
+void v8_inspector__RemoteObject__setWebDriverValue(v8_inspector::protocol::Runtime::RemoteObject* self, v8_inspector::protocol::Runtime::WebDriverValue* webDriverValue) {
+  self->setWebDriverValue(std::unique_ptr<v8_inspector::protocol::Runtime::WebDriverValue>(webDriverValue));
+}
+
+// RemoteObject - ObjectId
+bool v8_inspector__RemoteObject__hasObjectId(v8_inspector::protocol::Runtime::RemoteObject* self) {
+    return self->hasObjectId();
+  }
+  const char* v8_inspector__RemoteObject__getObjectId(v8_inspector::protocol::Runtime::RemoteObject* self) {
+      auto str = self->getObjectId(DEFAULT_STRING);
+      return toHeapCharPtr(str);
+  }
+  void v8_inspector__RemoteObject__setObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, const char* objectId, int objectId_len) {
+    self->setObjectId(v8_inspector::String16::fromUTF8(objectId, objectId_len));
+  }
+
+// RemoteObject - Preview
+bool v8_inspector__RemoteObject__hasPreview(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  return self->hasPreview();
+}
+const v8_inspector::protocol::Runtime::ObjectPreview* v8_inspector__RemoteObject__getPreview(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  return self->getPreview(nullptr);
+}
+void v8_inspector__RemoteObject__setPreview(v8_inspector::protocol::Runtime::RemoteObject* self, v8_inspector::protocol::Runtime::ObjectPreview* preview) {
+  self->setPreview(std::unique_ptr<v8_inspector::protocol::Runtime::ObjectPreview>(preview));
+}
+
+// RemoteObject - CustomPreview
+bool v8_inspector__RemoteObject__hasCustomPreview(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  return self->hasCustomPreview();
+}
+const v8_inspector::protocol::Runtime::CustomPreview* v8_inspector__RemoteObject__getCustomPreview(v8_inspector::protocol::Runtime::RemoteObject* self) {
+  return self->getCustomPreview(nullptr);
+}
+void v8_inspector__RemoteObject__setCustomPreview(v8_inspector::protocol::Runtime::RemoteObject* self, v8_inspector::protocol::Runtime::CustomPreview* customPreview) {
+  self->setCustomPreview(std::unique_ptr<v8_inspector::protocol::Runtime::CustomPreview>(customPreview));
 }
 
 // InspectorChannel

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1555,7 +1555,7 @@ void v8__base__SetDcheckFunction(void (*func)(const char*, int, const char*)) {
 /// @param allocator: A Zig std.mem.Allocator
 /// @param bytes: The number of bytes to allocate
 /// @returns A pointer to the allocated memory, null if allocation failed
-char* zigAlloc(void* allocator, uint64_t bytes);
+char* zigAlloc(const void* allocator, uint64_t bytes);
 
 static inline v8_inspector::StringView toStringView(const char *str, size_t length) {
     auto* stringView = reinterpret_cast<const uint8_t*>(str);
@@ -1580,7 +1580,7 @@ static inline std::string fromStringView(v8::Isolate* isolate, const v8_inspecto
 /// @param str: The string to return
 /// @param allocator: A Zig std.mem.Allocator
 /// @returns string pointer with null terminator, null if allocation failed
-const char* toHeapCharPtr(const v8_inspector::String16& str, void* allocator) {
+const char* toHeapCharPtr(const v8_inspector::String16& str, const void* allocator) {
     std::string utf8_str = str.utf8(); // Note the data*'s lifetime is tied to utf8_str and this may hold the string data on the stack as an SSO, so we need to copy it onto the heap.
     char* heap_str = zigAlloc(allocator, utf8_str.length() + 1); // +1 for null terminator, needed to communicate the length to Zig
     if (heap_str == nullptr) {
@@ -1671,7 +1671,7 @@ void v8_inspector__RemoteObject__DELETE(v8_inspector::protocol::Runtime::RemoteO
 }
 
 // RemoteObject - Type
-const char* v8_inspector__RemoteObject__getType(v8_inspector::protocol::Runtime::RemoteObject* self, void* allocator) {
+const char* v8_inspector__RemoteObject__getType(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getType();
   return toHeapCharPtr(str, allocator);
 }
@@ -1683,7 +1683,7 @@ void v8_inspector__RemoteObject__setType(v8_inspector::protocol::Runtime::Remote
 bool v8_inspector__RemoteObject__hasSubtype(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasSubtype();
 }
-const char* v8_inspector__RemoteObject__getSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, void* allocator) {
+const char* v8_inspector__RemoteObject__getSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getSubtype(DEFAULT_STRING);
   return toHeapCharPtr(str, allocator);
 }
@@ -1695,7 +1695,7 @@ void v8_inspector__RemoteObject__setSubtype(v8_inspector::protocol::Runtime::Rem
 bool v8_inspector__RemoteObject__hasClassName(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasClassName();
 }
-const char* v8_inspector__RemoteObject__getClassName(v8_inspector::protocol::Runtime::RemoteObject* self, void* allocator) {
+const char* v8_inspector__RemoteObject__getClassName(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getClassName(DEFAULT_STRING);
   return toHeapCharPtr(str, allocator);
 }
@@ -1718,7 +1718,7 @@ void v8_inspector__RemoteObject__setValue(v8_inspector::protocol::Runtime::Remot
 bool v8_inspector__RemoteObject__hasUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasUnserializableValue();
 }
-const char* v8_inspector__RemoteObject__getUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, void* allocator) {
+const char* v8_inspector__RemoteObject__getUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getUnserializableValue(DEFAULT_STRING);
   return toHeapCharPtr(str, allocator);
 }
@@ -1730,7 +1730,7 @@ void v8_inspector__RemoteObject__setUnserializableValue(v8_inspector::protocol::
 bool v8_inspector__RemoteObject__hasDescription(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasDescription();
 }
-const char* v8_inspector__RemoteObject__getDescription(v8_inspector::protocol::Runtime::RemoteObject* self, void* allocator) {
+const char* v8_inspector__RemoteObject__getDescription(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getDescription(DEFAULT_STRING);
   return toHeapCharPtr(str, allocator);
 }
@@ -1754,7 +1754,7 @@ bool v8_inspector__RemoteObject__hasObjectId(v8_inspector::protocol::Runtime::Re
   return self->hasObjectId();
 }
 
-const char* v8_inspector__RemoteObject__getObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, void* allocator) {
+const char* v8_inspector__RemoteObject__getObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getObjectId(DEFAULT_STRING);
   return toHeapCharPtr(str, allocator);
 }

--- a/src/binding.h
+++ b/src/binding.h
@@ -1030,17 +1030,17 @@ void v8_inspector__Inspector__ContextCreated(Inspector *self, const char *name,
 void v8_inspector__RemoteObject__DELETE(RemoteObject *self);
 
 // RemoteObject - Type
-const char* v8_inspector__RemoteObject__getType(RemoteObject* self);
+const char* v8_inspector__RemoteObject__getType(RemoteObject* self, void* allocator);
 void v8_inspector__RemoteObject__setType(RemoteObject* self, const char* type, int type_len);
 
 // RemoteObject - Subtype
 bool v8_inspector__RemoteObject__hasSubtype(RemoteObject* self);
-const char* v8_inspector__RemoteObject__getSubtype(RemoteObject* self);
+const char* v8_inspector__RemoteObject__getSubtype(RemoteObject* self, void* allocator);
 void v8_inspector__RemoteObject__setSubtype(RemoteObject* self, const char* subtype, int subtype_len);
 
 // RemoteObject - ClassName
 bool v8_inspector__RemoteObject__hasClassName(RemoteObject* self);
-const char* v8_inspector__RemoteObject__getClassName(RemoteObject* self);
+const char* v8_inspector__RemoteObject__getClassName(RemoteObject* self, void* allocator);
 void v8_inspector__RemoteObject__setClassName(RemoteObject* self, const char* className, int className_len);
 
 // RemoteObject - Value
@@ -1051,12 +1051,12 @@ bool v8_inspector__RemoteObject__hasValue(RemoteObject* self);
 
 //RemoteObject - UnserializableValue
 bool v8_inspector__RemoteObject__hasUnserializableValue(RemoteObject* self);
-const char* v8_inspector__RemoteObject__getUnserializableValue(RemoteObject* self);
+const char* v8_inspector__RemoteObject__getUnserializableValue(RemoteObject* self, void* allocator);
 void v8_inspector__RemoteObject__setUnserializableValue(RemoteObject* self, const char* unserializableValue, int unserializableValue_len);
 
 // RemoteObject - Description
 bool v8_inspector__RemoteObject__hasDescription(RemoteObject* self);
-const char* v8_inspector__RemoteObject__getDescription(RemoteObject* self);
+const char* v8_inspector__RemoteObject__getDescription(RemoteObject* self, void* allocator);
 void v8_inspector__RemoteObject__setDescription(RemoteObject* self, const char* description, int description_len);
 
 // RemoteObject - WebDriverValue
@@ -1066,7 +1066,7 @@ void v8_inspector__RemoteObject__setWebDriverValue(RemoteObject* self, WebDriver
 
 // RemoteObject - ObjectId
 bool v8_inspector__RemoteObject__hasObjectId(RemoteObject* self);
-const char* v8_inspector__RemoteObject__getObjectId(RemoteObject* self);
+const char* v8_inspector__RemoteObject__getObjectId(RemoteObject* self, void* allocator);
 void v8_inspector__RemoteObject__setObjectId(RemoteObject* self, const char* objectId, int objectId_len);
 
 // RemoteObject - Preview

--- a/src/binding.h
+++ b/src/binding.h
@@ -1030,17 +1030,17 @@ void v8_inspector__Inspector__ContextCreated(Inspector *self, const char *name,
 void v8_inspector__RemoteObject__DELETE(RemoteObject *self);
 
 // RemoteObject - Type
-const char* v8_inspector__RemoteObject__getType(RemoteObject* self, void* allocator);
+const char* v8_inspector__RemoteObject__getType(RemoteObject* self, const void* allocator);
 void v8_inspector__RemoteObject__setType(RemoteObject* self, const char* type, int type_len);
 
 // RemoteObject - Subtype
 bool v8_inspector__RemoteObject__hasSubtype(RemoteObject* self);
-const char* v8_inspector__RemoteObject__getSubtype(RemoteObject* self, void* allocator);
+const char* v8_inspector__RemoteObject__getSubtype(RemoteObject* self, const void* allocator);
 void v8_inspector__RemoteObject__setSubtype(RemoteObject* self, const char* subtype, int subtype_len);
 
 // RemoteObject - ClassName
 bool v8_inspector__RemoteObject__hasClassName(RemoteObject* self);
-const char* v8_inspector__RemoteObject__getClassName(RemoteObject* self, void* allocator);
+const char* v8_inspector__RemoteObject__getClassName(RemoteObject* self, const void* allocator);
 void v8_inspector__RemoteObject__setClassName(RemoteObject* self, const char* className, int className_len);
 
 // RemoteObject - Value
@@ -1051,12 +1051,12 @@ bool v8_inspector__RemoteObject__hasValue(RemoteObject* self);
 
 //RemoteObject - UnserializableValue
 bool v8_inspector__RemoteObject__hasUnserializableValue(RemoteObject* self);
-const char* v8_inspector__RemoteObject__getUnserializableValue(RemoteObject* self, void* allocator);
+const char* v8_inspector__RemoteObject__getUnserializableValue(RemoteObject* self, const void* allocator);
 void v8_inspector__RemoteObject__setUnserializableValue(RemoteObject* self, const char* unserializableValue, int unserializableValue_len);
 
 // RemoteObject - Description
 bool v8_inspector__RemoteObject__hasDescription(RemoteObject* self);
-const char* v8_inspector__RemoteObject__getDescription(RemoteObject* self, void* allocator);
+const char* v8_inspector__RemoteObject__getDescription(RemoteObject* self, const void* allocator);
 void v8_inspector__RemoteObject__setDescription(RemoteObject* self, const char* description, int description_len);
 
 // RemoteObject - WebDriverValue
@@ -1066,7 +1066,7 @@ void v8_inspector__RemoteObject__setWebDriverValue(RemoteObject* self, WebDriver
 
 // RemoteObject - ObjectId
 bool v8_inspector__RemoteObject__hasObjectId(RemoteObject* self);
-const char* v8_inspector__RemoteObject__getObjectId(RemoteObject* self, void* allocator);
+const char* v8_inspector__RemoteObject__getObjectId(RemoteObject* self, const void* allocator);
 void v8_inspector__RemoteObject__setObjectId(RemoteObject* self, const char* objectId, int objectId_len);
 
 // RemoteObject - Preview

--- a/src/binding.h
+++ b/src/binding.h
@@ -996,6 +996,9 @@ char* v8_inspector__Client__IMPL__descriptionForValueSubtype(
 
 // RemoteObject
 typedef struct RemoteObject RemoteObject;
+typedef struct WebDriverValue WebDriverValue;
+typedef struct ObjectPreview ObjectPreview;
+typedef struct CustomPreview CustomPreview;
 
 // InspectorSession
 
@@ -1005,7 +1008,7 @@ void v8_inspector__Session__dispatchProtocolMessage(InspectorSession *session, I
 RemoteObject* v8_inspector__Session__wrapObject(
     InspectorSession *session, Isolate *isolate,
     const Context* ctx, const Value* val,
-    const char *grpname, int grpname_len, bool generatepreview);
+    const char *grpname, usize grpname_len, bool generatepreview);
 
 // Inspector
 typedef struct Inspector Inspector;
@@ -1022,3 +1025,56 @@ void v8_inspector__Inspector__ContextCreated(Inspector *self, const char *name,
                                              const char *auxData, const usize auxData_len,
                                              int contextGroupId,
     const Context* context);
+
+// RemoteObject
+void v8_inspector__RemoteObject__DELETE(RemoteObject *self);
+
+// RemoteObject - Type
+const char* v8_inspector__RemoteObject__getType(RemoteObject* self);
+void v8_inspector__RemoteObject__setType(RemoteObject* self, const char* type, int type_len);
+
+// RemoteObject - Subtype
+bool v8_inspector__RemoteObject__hasSubtype(RemoteObject* self);
+const char* v8_inspector__RemoteObject__getSubtype(RemoteObject* self);
+void v8_inspector__RemoteObject__setSubtype(RemoteObject* self, const char* subtype, int subtype_len);
+
+// RemoteObject - ClassName
+bool v8_inspector__RemoteObject__hasClassName(RemoteObject* self);
+const char* v8_inspector__RemoteObject__getClassName(RemoteObject* self);
+void v8_inspector__RemoteObject__setClassName(RemoteObject* self, const char* className, int className_len);
+
+// RemoteObject - Value
+bool v8_inspector__RemoteObject__hasValue(RemoteObject* self);
+// Commented as these for now as the type should likely be the existing Value TBD
+// v8_inspector::protocol::Value* v8_inspector__RemoteObject__getValue(Rem;eObject* self);
+// void v8_inspector__RemoteObject__setValue(RemoteObject* self, v8_inspector::protocol::Value* value);
+
+//RemoteObject - UnserializableValue
+bool v8_inspector__RemoteObject__hasUnserializableValue(RemoteObject* self);
+const char* v8_inspector__RemoteObject__getUnserializableValue(RemoteObject* self);
+void v8_inspector__RemoteObject__setUnserializableValue(RemoteObject* self, const char* unserializableValue, int unserializableValue_len);
+
+// RemoteObject - Description
+bool v8_inspector__RemoteObject__hasDescription(RemoteObject* self);
+const char* v8_inspector__RemoteObject__getDescription(RemoteObject* self);
+void v8_inspector__RemoteObject__setDescription(RemoteObject* self, const char* description, int description_len);
+
+// RemoteObject - WebDriverValue
+bool v8_inspector__RemoteObject__hasWebDriverValue(RemoteObject* self);
+WebDriverValue* v8_inspector__RemoteObject__getWebDriverValue(RemoteObject* self);
+void v8_inspector__RemoteObject__setWebDriverValue(RemoteObject* self, WebDriverValue* webDriverValue);
+
+// RemoteObject - ObjectId
+bool v8_inspector__RemoteObject__hasObjectId(RemoteObject* self);
+const char* v8_inspector__RemoteObject__getObjectId(RemoteObject* self);
+void v8_inspector__RemoteObject__setObjectId(RemoteObject* self, const char* objectId, int objectId_len);
+
+// RemoteObject - Preview
+bool v8_inspector__RemoteObject__hasPreview(RemoteObject* self);
+const ObjectPreview* v8_inspector__RemoteObject__getPreview(RemoteObject* self);
+void v8_inspector__RemoteObject__setPreview(RemoteObject* self, ObjectPreview* preview);
+
+// RemoteObject - CustomPreview
+bool v8_inspector__RemoteObject__hasCustomPreview(RemoteObject* self);
+const CustomPreview* v8_inspector__RemoteObject__getCustomPreview(RemoteObject* self);
+void v8_inspector__RemoteObject__setCustomPreview(RemoteObject* self, CustomPreview* customPreview);

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -2679,98 +2679,82 @@ pub const InspectorSession = struct {
             grpname.len,
             generatepreview,
         ).?;
-        return RemoteObject.init(remote_object);
+        return RemoteObject{ .handle = remote_object };
     }
 };
 
-/// Currently RemoteObject is implemented as a plain struct as opposed to an interface to its members.
-/// This likely needs to change if we need to call setters in the future, or as more uscases with remoteObject appear.
-/// An interface like implementation is not prefered as V8 is inconsistend with handing out owning an non-owning memory. This is partly due to v8 using UTF16 strings.
-/// For an interface implementation: Some getters return owned memory (strings), while others return memory owned by V8 (objects).
-/// Now instead, we do not have to exposed that to our users, which only have to make a single deinit call.
+/// Note: Some getters return owned memory (strings), while others return memory owned by V8 (objects).
 /// The getters short-circuit if the default values is not available as converting the defaults to V8 causes unnecessary overhead.
 ///
 /// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-RemoteObject
 pub const RemoteObject = struct {
     handle: *c.RemoteObject,
-    type: []const u8,
-    subtype: ?[]const u8,
-    class_name: ?[]const u8,
-    // NotYetImplemented: value,
-    // NotYetImplemented: unserializable_value,
-    description: ?[]const u8,
-    // NotYetImplemented: web_driver_value,
-    object_id: ?[]const u8,
-    // NotYetImplemented: preview,
-    // NotYetImplemented: custom_preview,
-
-    pub fn init(handle: *c.RemoteObject) RemoteObject {
-        return .{
-            .handle = handle,
-            .type = RemoteObject.getType(handle),
-            .subtype = RemoteObject.getSubtype(handle),
-            .class_name = RemoteObject.getClassName(handle),
-            .description = RemoteObject.getDescription(handle),
-            .object_id = RemoteObject.getObjectId(handle),
-        };
-    }
 
     pub fn deinit(self: RemoteObject) void {
         c.v8_inspector__RemoteObject__DELETE(self.handle);
-        std.c.free(self.type);
-        if (self.subtype) |subtype| {
-            std.c.free(subtype);
-        }
-        if (self.class_name) |class_name| {
-            std.c.free(class_name);
-        }
-        if (self.description) |description| {
-            std.c.free(description);
-        }
-        if (self.object_id) |object_id| {
-            std.c.free(object_id);
-        }
     }
 
-    fn getType(handle: *c.RemoteObject) []const u8 {
-        const type_ = c.v8_inspector__RemoteObject__getType(handle);
+    pub fn getType(self: RemoteObject, allocator: *std.mem.Allocator) ![:0]const u8 {
+        const type_ = c.v8_inspector__RemoteObject__getType(self.handle, allocator);
+        if (type_ == null) {
+            return error.V8AllocFailed;
+        }
         const idx = std.mem.indexOfSentinel(u8, 0, type_);
-        return type_[0..idx];
+        return type_[0..idx :0];
     }
-    fn getSubtype(handle: *c.RemoteObject) ?[]const u8 {
-        if (!c.v8_inspector__RemoteObject__hasSubtype(handle)) {
+    pub fn getSubtype(self: RemoteObject, allocator: *std.mem.Allocator) !?[:0]const u8 {
+        if (!c.v8_inspector__RemoteObject__hasSubtype(self.handle)) {
             return null;
         }
 
-        const subtype = c.v8_inspector__RemoteObject__getSubtype(handle);
+        const subtype = c.v8_inspector__RemoteObject__getSubtype(self.handle, allocator);
+        if (subtype == null) {
+            return error.V8AllocFailed;
+        }
         const idx = std.mem.indexOfSentinel(u8, 0, subtype);
-        return subtype[0..idx];
+        return subtype[0..idx :0];
     }
-    fn getClassName(handle: *c.RemoteObject) ?[]const u8 {
-        if (!c.v8_inspector__RemoteObject__hasClassName(handle)) {
+    pub fn getClassName(self: RemoteObject, allocator: *std.mem.Allocator) !?[:0]const u8 {
+        if (!c.v8_inspector__RemoteObject__hasClassName(self.handle)) {
             return null;
         }
 
-        const class_name = c.v8_inspector__RemoteObject__getClassName(handle);
+        const class_name = c.v8_inspector__RemoteObject__getClassName(self.handle, allocator);
+        if (class_name == null) {
+            return error.V8AllocFailed;
+        }
         const idx = std.mem.indexOfSentinel(u8, 0, class_name);
-        return class_name[0..idx];
+        return class_name[0..idx :0];
     }
-    fn getDescription(handle: *c.RemoteObject) ?[]const u8 {
-        if (!c.v8_inspector__RemoteObject__hasDescription(handle)) {
+    pub fn getDescription(self: RemoteObject, allocator: *std.mem.Allocator) !?[:0]const u8 {
+        if (!c.v8_inspector__RemoteObject__hasDescription(self.handle)) {
             return null;
         }
 
-        const description = c.v8_inspector__RemoteObject__getDescription(handle);
+        const description = c.v8_inspector__RemoteObject__getDescription(self.handle, allocator);
+        if (description == null) {
+            return error.V8AllocFailed;
+        }
         const idx = std.mem.indexOfSentinel(u8, 0, description);
-        return description[0..idx];
+        return description[0..idx :0];
     }
-    fn getObjectId(handle: *c.RemoteObject) ?[]const u8 {
-        if (!c.v8_inspector__RemoteObject__hasObjectId(handle)) {
+    pub fn getObjectId(self: RemoteObject, allocator: *std.mem.Allocator) !?[:0]const u8 {
+        if (!c.v8_inspector__RemoteObject__hasObjectId(self.handle)) {
             return null;
         }
 
-        const object_id = c.v8_inspector__RemoteObject__getObjectId(handle);
+        const object_id = c.v8_inspector__RemoteObject__getObjectId(self.handle, allocator);
+        if (object_id == null) {
+            return error.V8AllocFailed;
+        }
         const idx = std.mem.indexOfSentinel(u8, 0, object_id);
-        return object_id[0..idx];
+        return object_id[0..idx :0];
     }
 };
+
+/// Enables C to allocate using the given Zig allocator
+pub export fn zigAlloc(self: *anyopaque, bytes: usize) callconv(.C) ?[*]u8 {
+    const allocator: *std.mem.Allocator = @ptrCast(@alignCast(self));
+    const allocated_bytes = allocator.alloc(u8, bytes) catch return null;
+    return allocated_bytes.ptr;
+}

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -2670,7 +2670,7 @@ pub const InspectorSession = struct {
     }
 
     pub fn wrapObject(self: InspectorSession, isolate: Isolate, ctx: Context, val: Value, grpname: []const u8, generatepreview: bool) !RemoteObject {
-        const remote_obj = c.v8_inspector__Session__wrapObject(
+        const remote_object = c.v8_inspector__Session__wrapObject(
             self.handle,
             isolate.handle,
             ctx.handle,
@@ -2679,125 +2679,98 @@ pub const InspectorSession = struct {
             grpname.len,
             generatepreview,
         ).?;
-        return RemoteObject{ .handle = remote_obj };
+        return RemoteObject.init(remote_object);
     }
 };
 
-/// RemoteObject is implemented as an interface to its members as opposed to a POD struct, since V8 is inconsistent with
-/// returning owning and non-owning data. This is partly due to v8 using UTF16 strings.
-/// NOTE: Some getters return owned memory (strings), while others return memory owned by V8 (objects).
-/// The latter are not freed by the caller, but the former must be freed.
-/// The getter methods short-circuit if the dafavalues is not available as converting the defaults to V8 causes unnecessary overhead.
+/// Currently RemoteObject is implemented as a plain struct as opposed to an interface to its members.
+/// This likely needs to change if we need to call setters in the future, or as more uscases with remoteObject appear.
+/// An interface like implementation is not prefered as V8 is inconsistend with handing out owning an non-owning memory. This is partly due to v8 using UTF16 strings.
+/// For an interface implementation: Some getters return owned memory (strings), while others return memory owned by V8 (objects).
+/// Now instead, we do not have to exposed that to our users, which only have to make a single deinit call.
+/// The getters short-circuit if the default values is not available as converting the defaults to V8 causes unnecessary overhead.
+///
+/// https://chromedevtools.github.io/devtools-protocol/tot/Runtime/#type-RemoteObject
 pub const RemoteObject = struct {
     handle: *c.RemoteObject,
+    type: []const u8,
+    subtype: ?[]const u8,
+    class_name: ?[]const u8,
+    // NotYetImplemented: value,
+    // NotYetImplemented: unserializable_value,
+    description: ?[]const u8,
+    // NotYetImplemented: web_driver_value,
+    object_id: ?[]const u8,
+    // NotYetImplemented: preview,
+    // NotYetImplemented: custom_preview,
+
+    pub fn init(handle: *c.RemoteObject) RemoteObject {
+        return .{
+            .handle = handle,
+            .type = RemoteObject.getType(handle),
+            .subtype = RemoteObject.getSubtype(handle),
+            .class_name = RemoteObject.getClassName(handle),
+            .description = RemoteObject.getDescription(handle),
+            .object_id = RemoteObject.getObjectId(handle),
+        };
+    }
 
     pub fn deinit(self: RemoteObject) void {
         c.v8_inspector__RemoteObject__DELETE(self.handle);
+        std.c.free(self.type);
+        if (self.subtype) |subtype| {
+            std.c.free(subtype);
+        }
+        if (self.class_name) |class_name| {
+            std.c.free(class_name);
+        }
+        if (self.description) |description| {
+            std.c.free(description);
+        }
+        if (self.object_id) |object_id| {
+            std.c.free(object_id);
+        }
     }
 
-    // Type
-    pub fn getType(self: RemoteObject) []const u8 {
-        const type_ = c.v8_inspector__RemoteObject__getType(self.handle);
+    fn getType(handle: *c.RemoteObject) []const u8 {
+        const type_ = c.v8_inspector__RemoteObject__getType(handle);
         const idx = std.mem.indexOfSentinel(u8, 0, type_);
         return type_[0..idx];
     }
-    pub fn setType(self: RemoteObject, type_: []const u8) void {
-        c.v8_inspector__RemoteObject__setType(self.handle, type_.ptr, type_.len);
-    }
-
-    // Subtype
-    pub fn hasSubtype(self: RemoteObject) bool {
-        return c.v8_inspector__RemoteObject__hasSubtype(self.handle);
-    }
-    pub fn getSubtype(self: RemoteObject) ?[]const u8 {
-        if (!c.v8_inspector__RemoteObject__hasSubtype(self.handle)) {
+    fn getSubtype(handle: *c.RemoteObject) ?[]const u8 {
+        if (!c.v8_inspector__RemoteObject__hasSubtype(handle)) {
             return null;
         }
 
-        const subtype = c.v8_inspector__RemoteObject__getSubtype(self.handle);
+        const subtype = c.v8_inspector__RemoteObject__getSubtype(handle);
         const idx = std.mem.indexOfSentinel(u8, 0, subtype);
         return subtype[0..idx];
     }
-    pub fn setSubtype(self: RemoteObject, subtype: []const u8) void {
-        c.v8_inspector__RemoteObject__setSubtype(self.handle, subtype.ptr, subtype.len);
-    }
-
-    // ClassName
-    pub fn hasClassName(self: RemoteObject) bool {
-        return c.v8_inspector__RemoteObject__hasClassName(self.handle);
-    }
-    pub fn getClassName(self: RemoteObject) ?[]const u8 {
-        if (!c.v8_inspector__RemoteObject__hasClassName(self.handle)) {
+    fn getClassName(handle: *c.RemoteObject) ?[]const u8 {
+        if (!c.v8_inspector__RemoteObject__hasClassName(handle)) {
             return null;
         }
 
-        const class_name = c.v8_inspector__RemoteObject__getClassName(self.handle);
+        const class_name = c.v8_inspector__RemoteObject__getClassName(handle);
         const idx = std.mem.indexOfSentinel(u8, 0, class_name);
         return class_name[0..idx];
     }
-
-    // Value
-    pub fn hasValue(self: RemoteObject) bool {
-        return c.v8_inspector__RemoteObject__hasValue(self.handle);
-    }
-    // TODO GET / SET
-
-    // UnserializableValue
-    pub fn hasUnserializableValue(self: RemoteObject) bool {
-        return c.v8_inspector__RemoteObject__hasUnserializableValue(self.handle);
-    }
-    // TODO GET / SET
-
-    // Description
-    pub fn hasDescription(self: RemoteObject) bool {
-        return c.v8_inspector__RemoteObject__hasDescription(self.handle);
-    }
-    pub fn getDescription(self: RemoteObject) ?[]const u8 {
-        if (!c.v8_inspector__RemoteObject__hasDescription(self.handle)) {
+    fn getDescription(handle: *c.RemoteObject) ?[]const u8 {
+        if (!c.v8_inspector__RemoteObject__hasDescription(handle)) {
             return null;
         }
 
-        const description = c.v8_inspector__RemoteObject__getDescription(self.handle);
+        const description = c.v8_inspector__RemoteObject__getDescription(handle);
         const idx = std.mem.indexOfSentinel(u8, 0, description);
         return description[0..idx];
     }
-    pub fn setDescription(self: RemoteObject, description: []const u8) void {
-        c.v8_inspector__RemoteObject__setDescription(self.handle, description.ptr, description.len);
-    }
-
-    // WebDriverValue
-    pub fn hasWebDriverValue(self: RemoteObject) bool {
-        return c.v8_inspector__RemoteObject__hasWebDriverValue(self.handle);
-    }
-    // TODO GET / SET
-
-    // ObjectId
-    pub fn hasObjectId(self: RemoteObject) bool {
-        return c.v8_inspector__RemoteObject__hasObjectId(self.handle);
-    }
-    pub fn getObjectId(self: RemoteObject) ?[]const u8 {
-        if (!c.v8_inspector__RemoteObject__hasObjectId(self.handle)) {
+    fn getObjectId(handle: *c.RemoteObject) ?[]const u8 {
+        if (!c.v8_inspector__RemoteObject__hasObjectId(handle)) {
             return null;
         }
 
-        const object_id = c.v8_inspector__RemoteObject__getObjectId(self.handle);
+        const object_id = c.v8_inspector__RemoteObject__getObjectId(handle);
         const idx = std.mem.indexOfSentinel(u8, 0, object_id);
         return object_id[0..idx];
     }
-
-    pub fn setObjectId(self: RemoteObject, object_id: []const u8) void {
-        c.v8_inspector__RemoteObject__setObjectId(self.handle, object_id.ptr, object_id.len);
-    }
-
-    // Preview
-    pub fn hasPreview(self: RemoteObject) bool {
-        return c.v8_inspector__RemoteObject__hasPreview(self.handle);
-    }
-    // TODO GET / SET
-
-    // CustomPreview
-    pub fn hasCustomPreview(self: RemoteObject) bool {
-        return c.v8_inspector__RemoteObject__hasCustomPreview(self.handle);
-    }
-    // TODO GET / SET
 };

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -2694,56 +2694,56 @@ pub const RemoteObject = struct {
         c.v8_inspector__RemoteObject__DELETE(self.handle);
     }
 
-    pub fn getType(self: RemoteObject, allocator: *std.mem.Allocator) ![:0]const u8 {
-        const type_ = c.v8_inspector__RemoteObject__getType(self.handle, allocator);
+    pub fn getType(self: RemoteObject, allocator: std.mem.Allocator) ![:0]const u8 {
+        const type_ = c.v8_inspector__RemoteObject__getType(self.handle, &allocator);
         if (type_ == null) {
             return error.V8AllocFailed;
         }
         const idx = std.mem.indexOfSentinel(u8, 0, type_);
         return type_[0..idx :0];
     }
-    pub fn getSubtype(self: RemoteObject, allocator: *std.mem.Allocator) !?[:0]const u8 {
+    pub fn getSubtype(self: RemoteObject, allocator: std.mem.Allocator) !?[:0]const u8 {
         if (!c.v8_inspector__RemoteObject__hasSubtype(self.handle)) {
             return null;
         }
 
-        const subtype = c.v8_inspector__RemoteObject__getSubtype(self.handle, allocator);
+        const subtype = c.v8_inspector__RemoteObject__getSubtype(self.handle, &allocator);
         if (subtype == null) {
             return error.V8AllocFailed;
         }
         const idx = std.mem.indexOfSentinel(u8, 0, subtype);
         return subtype[0..idx :0];
     }
-    pub fn getClassName(self: RemoteObject, allocator: *std.mem.Allocator) !?[:0]const u8 {
+    pub fn getClassName(self: RemoteObject, allocator: std.mem.Allocator) !?[:0]const u8 {
         if (!c.v8_inspector__RemoteObject__hasClassName(self.handle)) {
             return null;
         }
 
-        const class_name = c.v8_inspector__RemoteObject__getClassName(self.handle, allocator);
+        const class_name = c.v8_inspector__RemoteObject__getClassName(self.handle, &allocator);
         if (class_name == null) {
             return error.V8AllocFailed;
         }
         const idx = std.mem.indexOfSentinel(u8, 0, class_name);
         return class_name[0..idx :0];
     }
-    pub fn getDescription(self: RemoteObject, allocator: *std.mem.Allocator) !?[:0]const u8 {
+    pub fn getDescription(self: RemoteObject, allocator: std.mem.Allocator) !?[:0]const u8 {
         if (!c.v8_inspector__RemoteObject__hasDescription(self.handle)) {
             return null;
         }
 
-        const description = c.v8_inspector__RemoteObject__getDescription(self.handle, allocator);
+        const description = c.v8_inspector__RemoteObject__getDescription(self.handle, &allocator);
         if (description == null) {
             return error.V8AllocFailed;
         }
         const idx = std.mem.indexOfSentinel(u8, 0, description);
         return description[0..idx :0];
     }
-    pub fn getObjectId(self: RemoteObject, allocator: *std.mem.Allocator) !?[:0]const u8 {
+    pub fn getObjectId(self: RemoteObject, allocator: std.mem.Allocator) !?[:0]const u8 {
         if (!c.v8_inspector__RemoteObject__hasObjectId(self.handle)) {
             return null;
         }
 
-        const object_id = c.v8_inspector__RemoteObject__getObjectId(self.handle, allocator);
+        const object_id = c.v8_inspector__RemoteObject__getObjectId(self.handle, &allocator);
         if (object_id == null) {
             return error.V8AllocFailed;
         }

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -2678,17 +2678,126 @@ pub const InspectorSession = struct {
             grpname.ptr,
             grpname.len,
             generatepreview,
-        );
-        if (remote_obj) {
-            return RemoteObject{ .handle = remote_obj };
-        } else return error.JsException;
+        ).?;
+        return RemoteObject{ .handle = remote_obj };
     }
 };
 
+/// RemoteObject is implemented as an interface to its members as opposed to a POD struct, since V8 is inconsistent with
+/// returning owning and non-owning data. This is partly due to v8 using UTF16 strings.
+/// NOTE: Some getters return owned memory (strings), while others return memory owned by V8 (objects).
+/// The latter are not freed by the caller, but the former must be freed.
+/// The getter methods short-circuit if the dafavalues is not available as converting the defaults to V8 causes unnecessary overhead.
 pub const RemoteObject = struct {
     handle: *c.RemoteObject,
 
-    pub fn deinit(self: *RemoteObject) void {
+    pub fn deinit(self: RemoteObject) void {
         c.v8_inspector__RemoteObject__DELETE(self.handle);
     }
+
+    // Type
+    pub fn getType(self: RemoteObject) []const u8 {
+        const type_ = c.v8_inspector__RemoteObject__getType(self.handle);
+        const idx = std.mem.indexOfSentinel(u8, 0, type_);
+        return type_[0..idx];
+    }
+    pub fn setType(self: RemoteObject, type_: []const u8) void {
+        c.v8_inspector__RemoteObject__setType(self.handle, type_.ptr, type_.len);
+    }
+
+    // Subtype
+    pub fn hasSubtype(self: RemoteObject) bool {
+        return c.v8_inspector__RemoteObject__hasSubtype(self.handle);
+    }
+    pub fn getSubtype(self: RemoteObject) ?[]const u8 {
+        if (!c.v8_inspector__RemoteObject__hasSubtype(self.handle)) {
+            return null;
+        }
+
+        const subtype = c.v8_inspector__RemoteObject__getSubtype(self.handle);
+        const idx = std.mem.indexOfSentinel(u8, 0, subtype);
+        return subtype[0..idx];
+    }
+    pub fn setSubtype(self: RemoteObject, subtype: []const u8) void {
+        c.v8_inspector__RemoteObject__setSubtype(self.handle, subtype.ptr, subtype.len);
+    }
+
+    // ClassName
+    pub fn hasClassName(self: RemoteObject) bool {
+        return c.v8_inspector__RemoteObject__hasClassName(self.handle);
+    }
+    pub fn getClassName(self: RemoteObject) ?[]const u8 {
+        if (!c.v8_inspector__RemoteObject__hasClassName(self.handle)) {
+            return null;
+        }
+
+        const class_name = c.v8_inspector__RemoteObject__getClassName(self.handle);
+        const idx = std.mem.indexOfSentinel(u8, 0, class_name);
+        return class_name[0..idx];
+    }
+
+    // Value
+    pub fn hasValue(self: RemoteObject) bool {
+        return c.v8_inspector__RemoteObject__hasValue(self.handle);
+    }
+    // TODO GET / SET
+
+    // UnserializableValue
+    pub fn hasUnserializableValue(self: RemoteObject) bool {
+        return c.v8_inspector__RemoteObject__hasUnserializableValue(self.handle);
+    }
+    // TODO GET / SET
+
+    // Description
+    pub fn hasDescription(self: RemoteObject) bool {
+        return c.v8_inspector__RemoteObject__hasDescription(self.handle);
+    }
+    pub fn getDescription(self: RemoteObject) ?[]const u8 {
+        if (!c.v8_inspector__RemoteObject__hasDescription(self.handle)) {
+            return null;
+        }
+
+        const description = c.v8_inspector__RemoteObject__getDescription(self.handle);
+        const idx = std.mem.indexOfSentinel(u8, 0, description);
+        return description[0..idx];
+    }
+    pub fn setDescription(self: RemoteObject, description: []const u8) void {
+        c.v8_inspector__RemoteObject__setDescription(self.handle, description.ptr, description.len);
+    }
+
+    // WebDriverValue
+    pub fn hasWebDriverValue(self: RemoteObject) bool {
+        return c.v8_inspector__RemoteObject__hasWebDriverValue(self.handle);
+    }
+    // TODO GET / SET
+
+    // ObjectId
+    pub fn hasObjectId(self: RemoteObject) bool {
+        return c.v8_inspector__RemoteObject__hasObjectId(self.handle);
+    }
+    pub fn getObjectId(self: RemoteObject) ?[]const u8 {
+        if (!c.v8_inspector__RemoteObject__hasObjectId(self.handle)) {
+            return null;
+        }
+
+        const object_id = c.v8_inspector__RemoteObject__getObjectId(self.handle);
+        const idx = std.mem.indexOfSentinel(u8, 0, object_id);
+        return object_id[0..idx];
+    }
+
+    pub fn setObjectId(self: RemoteObject, object_id: []const u8) void {
+        c.v8_inspector__RemoteObject__setObjectId(self.handle, object_id.ptr, object_id.len);
+    }
+
+    // Preview
+    pub fn hasPreview(self: RemoteObject) bool {
+        return c.v8_inspector__RemoteObject__hasPreview(self.handle);
+    }
+    // TODO GET / SET
+
+    // CustomPreview
+    pub fn hasCustomPreview(self: RemoteObject) bool {
+        return c.v8_inspector__RemoteObject__hasCustomPreview(self.handle);
+    }
+    // TODO GET / SET
 };


### PR DESCRIPTION
Bindings to load the members of a RemoteObject, needed to implement resolveNode.

Currently we fetch all available members from RemoteObject and do not set them. Until our requirements change I think this implementation is preferable over one where we expose each member through getter/setters calls. As that would require the caller to manage the memory of each (not all) member that returns owning memory individually. (See alternative implementation in commit: 2aafa057459cef49305723c101e0ac7f16f3e9fe)

Testing will be added in a later as the current test set up does not work, but the implementation does work when called from the browser.