### PR TITLE
add named property handler

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -889,6 +889,12 @@ void v8__ObjectTemplate__SetIndexedHandler(
     ptr_to_local(&self)->SetHandler(configuration);
 }
 
+void v8__ObjectTemplate__SetNamedHandler(
+        const v8::ObjectTemplate& self,
+        const v8::NamedPropertyHandlerConfiguration& configuration) {
+    ptr_to_local(&self)->SetHandler(configuration);
+}
+
 // Array
 
 const v8::Array* v8__Array__New(

--- a/src/binding.h
+++ b/src/binding.h
@@ -808,7 +808,29 @@ typedef struct IndexedPropertyHandlerConfiguration {
 } IndexedPropertyHandlerConfiguration;
 void v8__ObjectTemplate__SetIndexedHandler(
     const ObjectTemplate* self,
-    IndexedPropertyHandlerConfiguration configuration);
+    const IndexedPropertyHandlerConfiguration* configuration);
+
+typedef void (*NamedPropertyGetterCallback)(const Name*, const PropertyCallbackInfo*);
+typedef void (*NamedPropertySetterCallback)(const Name*, const Value*, const PropertyCallbackInfo*);
+typedef void (*NamedPropertyQueryCallback)(const Name*, const PropertyCallbackInfo*);
+typedef void (*NamedPropertyDeleterCallback)(const Name*, const PropertyCallbackInfo*);
+typedef void (*NamedPropertyEnumeratorCallback)(const PropertyCallbackInfo*);
+typedef void (*NamedPropertyDefinerCallback)(const Name*, PropertyDescriptor* desc, const PropertyCallbackInfo*);
+typedef void (*NamedPropertyDescriptorCallback)(const Name*, const PropertyCallbackInfo*);
+typedef struct NamedPropertyHandlerConfiguration {
+    NamedPropertyGetterCallback getter;
+    NamedPropertySetterCallback setter;
+    NamedPropertyQueryCallback query;
+    NamedPropertyDeleterCallback deleter;
+    NamedPropertyEnumeratorCallback enumerator;
+    NamedPropertyDefinerCallback definer;
+    NamedPropertyDescriptorCallback descriptor;
+    const Value* data;
+    PropertyHandlerFlags flags;
+} NamedPropertyHandlerConfiguration;
+void v8__ObjectTemplate__SetNamedHandler(
+    const ObjectTemplate* self,
+    const NamedPropertyHandlerConfiguration* configuration);
 
 // ScriptOrigin
 typedef struct ScriptOriginOptions {

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -89,6 +89,24 @@ pub const IndexedPropertyHandlerConfiguration = struct {
     flags: c.PropertyHandlerFlags = PropertyHandlerFlags.None,
 };
 
+pub const NamedPropertyGetterCallback = c.NamedPropertyGetterCallback;
+pub const NamedPropertySetterCallback = c.NamedPropertySetterCallback;
+pub const NamedPropertyQueryCallback = c.NamedPropertyQueryCallback;
+pub const NamedPropertyDeleterCallback = c.NamedPropertyDeleterCallback;
+pub const NamedPropertyEnumeratorCallback = c.NamedPropertyEnumeratorCallback;
+pub const NamedPropertyDefinerCallback = c.NamedPropertyDefinerCallback;
+pub const NamedPropertyDescriptorCallback = c.NamedPropertyDescriptorCallback;
+pub const NamedPropertyHandlerConfiguration = struct {
+    getter: ?NamedPropertyGetterCallback = null,
+    setter: ?NamedPropertySetterCallback = null,
+    query: ?NamedPropertyQueryCallback = null,
+    deleter: ?NamedPropertyDeleterCallback = null,
+    enumerator: ?NamedPropertyEnumeratorCallback = null,
+    definer: ?NamedPropertyDefinerCallback = null,
+    descriptor: ?NamedPropertyDescriptorCallback = null,
+    flags: c.PropertyHandlerFlags = PropertyHandlerFlags.None,
+};
+
 pub const CreateParams = c.CreateParams;
 
 pub const SharedPtr = c.SharedPtr;
@@ -970,7 +988,7 @@ pub const ObjectTemplate = struct {
     }
 
     pub fn setIndexedProperty(self: Self, configuration: IndexedPropertyHandlerConfiguration, data_val: anytype) void {
-        c.v8__ObjectTemplate__SetIndexedHandler(self.handle, c.IndexedPropertyHandlerConfiguration{
+        const conf = c.IndexedPropertyHandlerConfiguration{
             .getter = configuration.getter orelse null,
             .setter = configuration.setter orelse null,
             .query = configuration.query orelse null,
@@ -980,7 +998,23 @@ pub const ObjectTemplate = struct {
             .descriptor = configuration.descriptor orelse null,
             .data = getDataHandle(data_val),
             .flags = configuration.flags,
-        });
+        };
+        c.v8__ObjectTemplate__SetIndexedHandler(self.handle, &conf);
+    }
+
+    pub fn setNamedProperty(self: Self, configuration: NamedPropertyHandlerConfiguration, data_val: anytype) void {
+        const conf = c.NamedPropertyHandlerConfiguration{
+            .getter = configuration.getter orelse null,
+            .setter = configuration.setter orelse null,
+            .query = configuration.query orelse null,
+            .deleter = configuration.deleter orelse null,
+            .enumerator = configuration.enumerator orelse null,
+            .definer = configuration.definer orelse null,
+            .descriptor = configuration.descriptor orelse null,
+            .data = getDataHandle(data_val),
+            .flags = configuration.flags,
+        };
+        c.v8__ObjectTemplate__SetNamedHandler(self.handle, &conf);
     }
 
     pub fn toValue(self: Self) Value {


### PR DESCRIPTION
Exposes the ObjectTemplate's SetHandler for NamedProperties, i.e. `obj["key"]`

This is needed for the jsruntime branch of browser: https://github.com/lightpanda-io/browser/pull/506. 

The github workflow install step uses releases for this project for the lib_v8 library, so adding this missing code here seems like a simple way to unblock those workflows without having to change them.