### PR TITLE
More string cleanup

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1736,11 +1736,9 @@ void v8_inspector__RemoteObject__DELETE(v8_inspector::protocol::Runtime::RemoteO
 }
 
 // RemoteObject - Type
-CZigString v8_inspector__RemoteObject__getType(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+bool v8_inspector__RemoteObject__getType(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString &out_type) {
   auto str = self->getType();
-  CZigString result;
-  allocString(toStringView(str), allocator, result);
-  return result;
+  return allocString(toStringView(str), allocator, out_type);
 }
 void v8_inspector__RemoteObject__setType(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString type) {
   self->setType(v8_inspector::String16::fromUTF8(type.ptr, type.len));
@@ -1750,11 +1748,9 @@ void v8_inspector__RemoteObject__setType(v8_inspector::protocol::Runtime::Remote
 bool v8_inspector__RemoteObject__hasSubtype(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasSubtype();
 }
-CZigString v8_inspector__RemoteObject__getSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+bool v8_inspector__RemoteObject__getSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString &subtype) {
   auto str = self->getSubtype(DEFAULT_STRING);
-  CZigString result;
-  allocString(toStringView(str), allocator, result);
-  return result;
+  return allocString(toStringView(str), allocator, subtype);
 }
 void v8_inspector__RemoteObject__setSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString subtype) {
   self->setSubtype(v8_inspector::String16::fromUTF8(subtype.ptr, subtype.len));
@@ -1764,11 +1760,9 @@ void v8_inspector__RemoteObject__setSubtype(v8_inspector::protocol::Runtime::Rem
 bool v8_inspector__RemoteObject__hasClassName(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasClassName();
 }
-CZigString v8_inspector__RemoteObject__getClassName(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+bool v8_inspector__RemoteObject__getClassName(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString &className) {
   auto str = self->getClassName(DEFAULT_STRING);
-  CZigString result;
-  allocString(toStringView(str), allocator, result);
-  return result;
+  return allocString(toStringView(str), allocator, className);
 }
 void v8_inspector__RemoteObject__setClassName(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString className) {
   self->setClassName(v8_inspector::String16::fromUTF8(className.ptr, className.len));
@@ -1789,11 +1783,9 @@ void v8_inspector__RemoteObject__setValue(v8_inspector::protocol::Runtime::Remot
 bool v8_inspector__RemoteObject__hasUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasUnserializableValue();
 }
-CZigString v8_inspector__RemoteObject__getUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+bool v8_inspector__RemoteObject__getUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString &unserializableValue) {
   auto str = self->getUnserializableValue(DEFAULT_STRING);
-  CZigString result;
-  allocString(toStringView(str), allocator, result);
-  return result;
+  return allocString(toStringView(str), allocator, unserializableValue);
 }
 void v8_inspector__RemoteObject__setUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString unserializableValue) {
   self->setUnserializableValue(v8_inspector::String16::fromUTF8(unserializableValue.ptr, unserializableValue.len));
@@ -1803,11 +1795,9 @@ void v8_inspector__RemoteObject__setUnserializableValue(v8_inspector::protocol::
 bool v8_inspector__RemoteObject__hasDescription(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasDescription();
 }
-CZigString v8_inspector__RemoteObject__getDescription(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+bool v8_inspector__RemoteObject__getDescription(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString &description) {
   auto str = self->getDescription(DEFAULT_STRING);
-  CZigString result;
-  allocString(toStringView(str), allocator, result);
-  return result;
+  return allocString(toStringView(str), allocator, description);
 }
 void v8_inspector__RemoteObject__setDescription(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString description) {
   self->setDescription(v8_inspector::String16::fromUTF8(description.ptr, description.len));
@@ -1829,11 +1819,9 @@ bool v8_inspector__RemoteObject__hasObjectId(v8_inspector::protocol::Runtime::Re
   return self->hasObjectId();
 }
 
-CZigString v8_inspector__RemoteObject__getObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+bool v8_inspector__RemoteObject__getObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString &objectId) {
   auto str = self->getObjectId(DEFAULT_STRING);
-  CZigString result;
-  allocString(toStringView(str), allocator, result);
-  return result;
+  return allocString(toStringView(str), allocator, objectId);
 }
   void v8_inspector__RemoteObject__setObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString objectId) {
   self->setObjectId(v8_inspector::String16::fromUTF8(objectId.ptr, objectId.len));

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1736,11 +1736,9 @@ void v8_inspector__RemoteObject__DELETE(v8_inspector::protocol::Runtime::RemoteO
 }
 
 // RemoteObject - Type
-CZigString v8_inspector__RemoteObject__getType(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+bool v8_inspector__RemoteObject__getType(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString& out_type) {
   auto str = self->getType();
-  CZigString result;
-  allocString(toStringView(str), allocator, result);
-  return result;
+  return allocString(toStringView(str), allocator, out_type);
 }
 void v8_inspector__RemoteObject__setType(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString type) {
   self->setType(v8_inspector::String16::fromUTF8(type.ptr, type.len));
@@ -1750,11 +1748,9 @@ void v8_inspector__RemoteObject__setType(v8_inspector::protocol::Runtime::Remote
 bool v8_inspector__RemoteObject__hasSubtype(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasSubtype();
 }
-CZigString v8_inspector__RemoteObject__getSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+bool v8_inspector__RemoteObject__getSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString& out_subtype) {
   auto str = self->getSubtype(DEFAULT_STRING);
-  CZigString result;
-  allocString(toStringView(str), allocator, result);
-  return result;
+  return allocString(toStringView(str), allocator, out_subtype);
 }
 void v8_inspector__RemoteObject__setSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString subtype) {
   self->setSubtype(v8_inspector::String16::fromUTF8(subtype.ptr, subtype.len));
@@ -1764,11 +1760,9 @@ void v8_inspector__RemoteObject__setSubtype(v8_inspector::protocol::Runtime::Rem
 bool v8_inspector__RemoteObject__hasClassName(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasClassName();
 }
-CZigString v8_inspector__RemoteObject__getClassName(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+bool v8_inspector__RemoteObject__getClassName(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString& out_className) {
   auto str = self->getClassName(DEFAULT_STRING);
-  CZigString result;
-  allocString(toStringView(str), allocator, result);
-  return result;
+  return allocString(toStringView(str), allocator, out_className);
 }
 void v8_inspector__RemoteObject__setClassName(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString className) {
   self->setClassName(v8_inspector::String16::fromUTF8(className.ptr, className.len));
@@ -1789,11 +1783,9 @@ void v8_inspector__RemoteObject__setValue(v8_inspector::protocol::Runtime::Remot
 bool v8_inspector__RemoteObject__hasUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasUnserializableValue();
 }
-CZigString v8_inspector__RemoteObject__getUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+bool v8_inspector__RemoteObject__getUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString& out_unserializableValue) {
   auto str = self->getUnserializableValue(DEFAULT_STRING);
-  CZigString result;
-  allocString(toStringView(str), allocator, result);
-  return result;
+  return allocString(toStringView(str), allocator, out_unserializableValue);
 }
 void v8_inspector__RemoteObject__setUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString unserializableValue) {
   self->setUnserializableValue(v8_inspector::String16::fromUTF8(unserializableValue.ptr, unserializableValue.len));
@@ -1803,11 +1795,9 @@ void v8_inspector__RemoteObject__setUnserializableValue(v8_inspector::protocol::
 bool v8_inspector__RemoteObject__hasDescription(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasDescription();
 }
-CZigString v8_inspector__RemoteObject__getDescription(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+bool v8_inspector__RemoteObject__getDescription(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString& out_description) {
   auto str = self->getDescription(DEFAULT_STRING);
-  CZigString result;
-  allocString(toStringView(str), allocator, result);
-  return result;
+  return allocString(toStringView(str), allocator, out_description);
 }
 void v8_inspector__RemoteObject__setDescription(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString description) {
   self->setDescription(v8_inspector::String16::fromUTF8(description.ptr, description.len));
@@ -1829,13 +1819,11 @@ bool v8_inspector__RemoteObject__hasObjectId(v8_inspector::protocol::Runtime::Re
   return self->hasObjectId();
 }
 
-CZigString v8_inspector__RemoteObject__getObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+bool v8_inspector__RemoteObject__getObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString& out_objectId) {
   auto str = self->getObjectId(DEFAULT_STRING);
-  CZigString result;
-  allocString(toStringView(str), allocator, result);
-  return result;
+  return allocString(toStringView(str), allocator, out_objectId);
 }
-  void v8_inspector__RemoteObject__setObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString objectId) {
+void v8_inspector__RemoteObject__setObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString objectId) {
   self->setObjectId(v8_inspector::String16::fromUTF8(objectId.ptr, objectId.len));
 }
 

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1601,9 +1601,9 @@ static inline std::string fromStringView(v8::Isolate* isolate, const v8_inspecto
 /// @param output: Points to the now allocated string on the heap (without sentinel \0), NULL if view was null, invalid if allocation failed
 /// @returns false if allocation errored
 bool allocString(const v8_inspector::StringView& input, const void* allocator, CZigString& output) {
+    output.ptr = nullptr;
+    output.len = 0;
     if (input.characters8() == nullptr) {
-        output.ptr = nullptr;
-        output.len = 0;
         return true;
     }
 
@@ -1736,9 +1736,11 @@ void v8_inspector__RemoteObject__DELETE(v8_inspector::protocol::Runtime::RemoteO
 }
 
 // RemoteObject - Type
-bool v8_inspector__RemoteObject__getType(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString& out_type) {
+CZigString v8_inspector__RemoteObject__getType(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getType();
-  return allocString(toStringView(str), allocator, out_type);
+  CZigString result;
+  allocString(toStringView(str), allocator, result);
+  return result;
 }
 void v8_inspector__RemoteObject__setType(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString type) {
   self->setType(v8_inspector::String16::fromUTF8(type.ptr, type.len));
@@ -1748,9 +1750,11 @@ void v8_inspector__RemoteObject__setType(v8_inspector::protocol::Runtime::Remote
 bool v8_inspector__RemoteObject__hasSubtype(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasSubtype();
 }
-bool v8_inspector__RemoteObject__getSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString& out_subtype) {
+CZigString v8_inspector__RemoteObject__getSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getSubtype(DEFAULT_STRING);
-  return allocString(toStringView(str), allocator, out_subtype);
+  CZigString result;
+  allocString(toStringView(str), allocator, result);
+  return result;
 }
 void v8_inspector__RemoteObject__setSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString subtype) {
   self->setSubtype(v8_inspector::String16::fromUTF8(subtype.ptr, subtype.len));
@@ -1760,9 +1764,11 @@ void v8_inspector__RemoteObject__setSubtype(v8_inspector::protocol::Runtime::Rem
 bool v8_inspector__RemoteObject__hasClassName(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasClassName();
 }
-bool v8_inspector__RemoteObject__getClassName(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString& out_className) {
+CZigString v8_inspector__RemoteObject__getClassName(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getClassName(DEFAULT_STRING);
-  return allocString(toStringView(str), allocator, out_className);
+  CZigString result;
+  allocString(toStringView(str), allocator, result);
+  return result;
 }
 void v8_inspector__RemoteObject__setClassName(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString className) {
   self->setClassName(v8_inspector::String16::fromUTF8(className.ptr, className.len));
@@ -1783,9 +1789,11 @@ void v8_inspector__RemoteObject__setValue(v8_inspector::protocol::Runtime::Remot
 bool v8_inspector__RemoteObject__hasUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasUnserializableValue();
 }
-bool v8_inspector__RemoteObject__getUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString& out_unserializableValue) {
+CZigString v8_inspector__RemoteObject__getUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getUnserializableValue(DEFAULT_STRING);
-  return allocString(toStringView(str), allocator, out_unserializableValue);
+  CZigString result;
+  allocString(toStringView(str), allocator, result);
+  return result;
 }
 void v8_inspector__RemoteObject__setUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString unserializableValue) {
   self->setUnserializableValue(v8_inspector::String16::fromUTF8(unserializableValue.ptr, unserializableValue.len));
@@ -1795,9 +1803,11 @@ void v8_inspector__RemoteObject__setUnserializableValue(v8_inspector::protocol::
 bool v8_inspector__RemoteObject__hasDescription(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasDescription();
 }
-bool v8_inspector__RemoteObject__getDescription(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString& out_description) {
+CZigString v8_inspector__RemoteObject__getDescription(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getDescription(DEFAULT_STRING);
-  return allocString(toStringView(str), allocator, out_description);
+  CZigString result;
+  allocString(toStringView(str), allocator, result);
+  return result;
 }
 void v8_inspector__RemoteObject__setDescription(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString description) {
   self->setDescription(v8_inspector::String16::fromUTF8(description.ptr, description.len));
@@ -1819,11 +1829,13 @@ bool v8_inspector__RemoteObject__hasObjectId(v8_inspector::protocol::Runtime::Re
   return self->hasObjectId();
 }
 
-bool v8_inspector__RemoteObject__getObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator, CZigString& out_objectId) {
+CZigString v8_inspector__RemoteObject__getObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getObjectId(DEFAULT_STRING);
-  return allocString(toStringView(str), allocator, out_objectId);
+  CZigString result;
+  allocString(toStringView(str), allocator, result);
+  return result;
 }
-void v8_inspector__RemoteObject__setObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString objectId) {
+  void v8_inspector__RemoteObject__setObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString objectId) {
   self->setObjectId(v8_inspector::String16::fromUTF8(objectId.ptr, objectId.len));
 }
 

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1557,10 +1557,10 @@ void v8__base__SetDcheckFunction(void (*func)(const char*, int, const char*)) {
 
 // Utils
 
-struct CZigString {
-    const char *ptr = nullptr;
-    uint64_t len = 0;
-};
+extern "C" typedef struct {
+    const char *ptr;
+    uint64_t len;
+} CZigString;
 
 /// Header for Zig
 /// Allocates `bytes` bytes of memory using the allocator.
@@ -1594,25 +1594,11 @@ static inline std::string fromStringView(v8::Isolate* isolate, const v8_inspecto
   return *result;
 }
 
-/// Allocates a string as utf8 on the heap, such that it can be returned to Zig.
-/// @param str: The string to return
-/// @param allocator: A Zig std.mem.Allocator
-/// @returns string pointer with null terminator, null if allocation failed
-const char* allocStringWith0(const v8_inspector::String16& str, const void* allocator) {
-    std::string utf8_str = str.utf8(); // Note the data*'s lifetime is tied to utf8_str and this may hold the string data on the stack as an SSO, so we need to copy it onto the heap.
-    char* heap_str = zigAlloc(allocator, utf8_str.length() + 1); // +1 for null terminator, needed to communicate the length to Zig
-    if (heap_str == nullptr) {
-      return nullptr;
-    }
-    strcpy(heap_str, utf8_str.c_str());
-    return heap_str;   
-}
-
 /// Allocates a string as utf8 on the allocator without \0 terminator, for use in Zig.
 /// The strings pointer and length should therefore be returned together
-/// @param str: The string contents to allocate
+/// @param input: The string contents to allocate
 /// @param allocator: A Zig std.mem.Allocator
-/// @param out: Points to the now allocated string on the heap (without sentinel \0), NULL if view was null, invalid if allocation failed
+/// @param output: Points to the now allocated string on the heap (without sentinel \0), NULL if view was null, invalid if allocation failed
 /// @returns false if allocation errored
 bool allocString(const v8_inspector::StringView& input, const void* allocator, CZigString& output) {
     if (input.characters8() == nullptr) {
@@ -1621,7 +1607,7 @@ bool allocString(const v8_inspector::StringView& input, const void* allocator, C
         return true;
     }
 
-    std::string utf8_str; // Harmless if not used by 8bit string
+    std::string utf8_str;
     if (input.is8Bit()) {
         output.len = input.length();
     } else {
@@ -1750,36 +1736,42 @@ void v8_inspector__RemoteObject__DELETE(v8_inspector::protocol::Runtime::RemoteO
 }
 
 // RemoteObject - Type
-const char* v8_inspector__RemoteObject__getType(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+CZigString v8_inspector__RemoteObject__getType(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getType();
-  return allocStringWith0(str, allocator);
+  CZigString result;
+  allocString(toStringView(str), allocator, result);
+  return result;
 }
-void v8_inspector__RemoteObject__setType(v8_inspector::protocol::Runtime::RemoteObject* self, const char* type, int type_len) {
-  self->setType(v8_inspector::String16::fromUTF8(type, type_len));
+void v8_inspector__RemoteObject__setType(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString type) {
+  self->setType(v8_inspector::String16::fromUTF8(type.ptr, type.len));
 }
 
 // RemoteObject - Subtype
 bool v8_inspector__RemoteObject__hasSubtype(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasSubtype();
 }
-const char* v8_inspector__RemoteObject__getSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+CZigString v8_inspector__RemoteObject__getSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getSubtype(DEFAULT_STRING);
-  return allocStringWith0(str, allocator);
+  CZigString result;
+  allocString(toStringView(str), allocator, result);
+  return result;
 }
-void v8_inspector__RemoteObject__setSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, const char* subtype, int subtype_len) {
-  self->setSubtype(v8_inspector::String16::fromUTF8(subtype, subtype_len));
+void v8_inspector__RemoteObject__setSubtype(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString subtype) {
+  self->setSubtype(v8_inspector::String16::fromUTF8(subtype.ptr, subtype.len));
 }
 
 // RemoteObject - ClassName
 bool v8_inspector__RemoteObject__hasClassName(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasClassName();
 }
-const char* v8_inspector__RemoteObject__getClassName(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+CZigString v8_inspector__RemoteObject__getClassName(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getClassName(DEFAULT_STRING);
-  return allocStringWith0(str, allocator);
+  CZigString result;
+  allocString(toStringView(str), allocator, result);
+  return result;
 }
-void v8_inspector__RemoteObject__setClassName(v8_inspector::protocol::Runtime::RemoteObject* self, const char* className, int className_len) {
-  self->setClassName(v8_inspector::String16::fromUTF8(className, className_len));
+void v8_inspector__RemoteObject__setClassName(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString className) {
+  self->setClassName(v8_inspector::String16::fromUTF8(className.ptr, className.len));
 }
 
 // RemoteObject - Value
@@ -1793,28 +1785,32 @@ void v8_inspector__RemoteObject__setValue(v8_inspector::protocol::Runtime::Remot
   self->setValue(std::unique_ptr<v8_inspector::protocol::Value>(value));
 }
 
-//RemoteObject - UnserializableValue
+// RemoteObject - UnserializableValue
 bool v8_inspector__RemoteObject__hasUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasUnserializableValue();
 }
-const char* v8_inspector__RemoteObject__getUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+CZigString v8_inspector__RemoteObject__getUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getUnserializableValue(DEFAULT_STRING);
-  return allocStringWith0(str, allocator);
+  CZigString result;
+  allocString(toStringView(str), allocator, result);
+  return result;
 }
-void v8_inspector__RemoteObject__setUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, const char* unserializableValue, int unserializableValue_len) {
-  self->setUnserializableValue(v8_inspector::String16::fromUTF8(unserializableValue, unserializableValue_len));
+void v8_inspector__RemoteObject__setUnserializableValue(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString unserializableValue) {
+  self->setUnserializableValue(v8_inspector::String16::fromUTF8(unserializableValue.ptr, unserializableValue.len));
 }
 
 // RemoteObject - Description
 bool v8_inspector__RemoteObject__hasDescription(v8_inspector::protocol::Runtime::RemoteObject* self) {
   return self->hasDescription();
 }
-const char* v8_inspector__RemoteObject__getDescription(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+CZigString v8_inspector__RemoteObject__getDescription(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getDescription(DEFAULT_STRING);
-  return allocStringWith0(str, allocator);
+  CZigString result;
+  allocString(toStringView(str), allocator, result);
+  return result;
 }
-void v8_inspector__RemoteObject__setDescription(v8_inspector::protocol::Runtime::RemoteObject* self, const char* description, int description_len) {
-  self->setDescription(v8_inspector::String16::fromUTF8(description, description_len));
+void v8_inspector__RemoteObject__setDescription(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString description) {
+  self->setDescription(v8_inspector::String16::fromUTF8(description.ptr, description.len));
 }
 
 // RemoteObject - WebDriverValue
@@ -1833,12 +1829,14 @@ bool v8_inspector__RemoteObject__hasObjectId(v8_inspector::protocol::Runtime::Re
   return self->hasObjectId();
 }
 
-const char* v8_inspector__RemoteObject__getObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
+CZigString v8_inspector__RemoteObject__getObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, const void* allocator) {
   auto str = self->getObjectId(DEFAULT_STRING);
-  return allocStringWith0(str, allocator);
+  CZigString result;
+  allocString(toStringView(str), allocator, result);
+  return result;
 }
-  void v8_inspector__RemoteObject__setObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, const char* objectId, int objectId_len) {
-  self->setObjectId(v8_inspector::String16::fromUTF8(objectId, objectId_len));
+  void v8_inspector__RemoteObject__setObjectId(v8_inspector::protocol::Runtime::RemoteObject* self, CZigString objectId) {
+  self->setObjectId(v8_inspector::String16::fromUTF8(objectId.ptr, objectId.len));
 }
 
 // RemoteObject - Preview

--- a/src/binding.h
+++ b/src/binding.h
@@ -1068,18 +1068,18 @@ void v8_inspector__Inspector__ContextCreated(Inspector *self, const char *name,
 void v8_inspector__RemoteObject__DELETE(RemoteObject *self);
 
 // RemoteObject - Type
-const char* v8_inspector__RemoteObject__getType(RemoteObject* self, const void* allocator);
-void v8_inspector__RemoteObject__setType(RemoteObject* self, const char* type, int type_len);
+CZigString v8_inspector__RemoteObject__getType(RemoteObject* self, const void* allocator);
+void v8_inspector__RemoteObject__setType(RemoteObject* self, CZigString type);
 
 // RemoteObject - Subtype
 bool v8_inspector__RemoteObject__hasSubtype(RemoteObject* self);
-const char* v8_inspector__RemoteObject__getSubtype(RemoteObject* self, const void* allocator);
-void v8_inspector__RemoteObject__setSubtype(RemoteObject* self, const char* subtype, int subtype_len);
+CZigString v8_inspector__RemoteObject__getSubtype(RemoteObject* self, const void* allocator);
+void v8_inspector__RemoteObject__setSubtype(RemoteObject* self, CZigString subtype);
 
 // RemoteObject - ClassName
 bool v8_inspector__RemoteObject__hasClassName(RemoteObject* self);
-const char* v8_inspector__RemoteObject__getClassName(RemoteObject* self, const void* allocator);
-void v8_inspector__RemoteObject__setClassName(RemoteObject* self, const char* className, int className_len);
+CZigString v8_inspector__RemoteObject__getClassName(RemoteObject* self, const void* allocator);
+void v8_inspector__RemoteObject__setClassName(RemoteObject* self, CZigString className);
 
 // RemoteObject - Value
 bool v8_inspector__RemoteObject__hasValue(RemoteObject* self);
@@ -1089,13 +1089,13 @@ bool v8_inspector__RemoteObject__hasValue(RemoteObject* self);
 
 //RemoteObject - UnserializableValue
 bool v8_inspector__RemoteObject__hasUnserializableValue(RemoteObject* self);
-const char* v8_inspector__RemoteObject__getUnserializableValue(RemoteObject* self, const void* allocator);
-void v8_inspector__RemoteObject__setUnserializableValue(RemoteObject* self, const char* unserializableValue, int unserializableValue_len);
+CZigString v8_inspector__RemoteObject__getUnserializableValue(RemoteObject* self, const void* allocator);
+void v8_inspector__RemoteObject__setUnserializableValue(RemoteObject* self, CZigString unserializableValue);
 
 // RemoteObject - Description
 bool v8_inspector__RemoteObject__hasDescription(RemoteObject* self);
-const char* v8_inspector__RemoteObject__getDescription(RemoteObject* self, const void* allocator);
-void v8_inspector__RemoteObject__setDescription(RemoteObject* self, const char* description, int description_len);
+CZigString v8_inspector__RemoteObject__getDescription(RemoteObject* self, const void* allocator);
+void v8_inspector__RemoteObject__setDescription(RemoteObject* self, CZigString description);
 
 // RemoteObject - WebDriverValue
 bool v8_inspector__RemoteObject__hasWebDriverValue(RemoteObject* self);
@@ -1104,8 +1104,8 @@ void v8_inspector__RemoteObject__setWebDriverValue(RemoteObject* self, WebDriver
 
 // RemoteObject - ObjectId
 bool v8_inspector__RemoteObject__hasObjectId(RemoteObject* self);
-const char* v8_inspector__RemoteObject__getObjectId(RemoteObject* self, const void* allocator);
-void v8_inspector__RemoteObject__setObjectId(RemoteObject* self, const char* objectId, int objectId_len);
+CZigString v8_inspector__RemoteObject__getObjectId(RemoteObject* self, const void* allocator);
+void v8_inspector__RemoteObject__setObjectId(RemoteObject* self, CZigString objectId);
 
 // RemoteObject - Preview
 bool v8_inspector__RemoteObject__hasPreview(RemoteObject* self);

--- a/src/binding.h
+++ b/src/binding.h
@@ -1068,17 +1068,17 @@ void v8_inspector__Inspector__ContextCreated(Inspector *self, const char *name,
 void v8_inspector__RemoteObject__DELETE(RemoteObject *self);
 
 // RemoteObject - Type
-CZigString v8_inspector__RemoteObject__getType(RemoteObject* self, const void* allocator);
+bool v8_inspector__RemoteObject__getType(RemoteObject* self, const void* allocator, CZigString* out_type);
 void v8_inspector__RemoteObject__setType(RemoteObject* self, CZigString type);
 
 // RemoteObject - Subtype
 bool v8_inspector__RemoteObject__hasSubtype(RemoteObject* self);
-CZigString v8_inspector__RemoteObject__getSubtype(RemoteObject* self, const void* allocator);
+bool v8_inspector__RemoteObject__getSubtype(RemoteObject* self, const void* allocator, CZigString* out_subtype);
 void v8_inspector__RemoteObject__setSubtype(RemoteObject* self, CZigString subtype);
 
 // RemoteObject - ClassName
 bool v8_inspector__RemoteObject__hasClassName(RemoteObject* self);
-CZigString v8_inspector__RemoteObject__getClassName(RemoteObject* self, const void* allocator);
+bool v8_inspector__RemoteObject__getClassName(RemoteObject* self, const void* allocator, CZigString* out_className);
 void v8_inspector__RemoteObject__setClassName(RemoteObject* self, CZigString className);
 
 // RemoteObject - Value
@@ -1089,12 +1089,12 @@ bool v8_inspector__RemoteObject__hasValue(RemoteObject* self);
 
 //RemoteObject - UnserializableValue
 bool v8_inspector__RemoteObject__hasUnserializableValue(RemoteObject* self);
-CZigString v8_inspector__RemoteObject__getUnserializableValue(RemoteObject* self, const void* allocator);
+bool v8_inspector__RemoteObject__getUnserializableValue(RemoteObject* self, const void* allocator, CZigString* out_unserializableValue);
 void v8_inspector__RemoteObject__setUnserializableValue(RemoteObject* self, CZigString unserializableValue);
 
 // RemoteObject - Description
 bool v8_inspector__RemoteObject__hasDescription(RemoteObject* self);
-CZigString v8_inspector__RemoteObject__getDescription(RemoteObject* self, const void* allocator);
+bool v8_inspector__RemoteObject__getDescription(RemoteObject* self, const void* allocator, CZigString* out_description);
 void v8_inspector__RemoteObject__setDescription(RemoteObject* self, CZigString description);
 
 // RemoteObject - WebDriverValue
@@ -1104,7 +1104,7 @@ void v8_inspector__RemoteObject__setWebDriverValue(RemoteObject* self, WebDriver
 
 // RemoteObject - ObjectId
 bool v8_inspector__RemoteObject__hasObjectId(RemoteObject* self);
-CZigString v8_inspector__RemoteObject__getObjectId(RemoteObject* self, const void* allocator);
+bool v8_inspector__RemoteObject__getObjectId(RemoteObject* self, const void* allocator, CZigString* out_objectId);
 void v8_inspector__RemoteObject__setObjectId(RemoteObject* self, CZigString objectId);
 
 // RemoteObject - Preview

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -2778,55 +2778,37 @@ pub const RemoteObject = struct {
     }
 
     pub fn getType(self: RemoteObject, allocator: std.mem.Allocator) ![]const u8 {
-        const ctype_ = c.v8_inspector__RemoteObject__getType(self.handle, &allocator);
-        if (CZigStringToString(ctype_)) |type_| {
-            return type_;
-        }
-        return error.V8AllocFailed;
+        var ctype_: c.CZigString = .{ .ptr = null, .len = 0 };
+        if (!c.v8_inspector__RemoteObject__getType(self.handle, &allocator, &ctype_)) return error.V8AllocFailed;
+        return CZigStringToString(ctype_) orelse return error.InvalidType;
     }
     pub fn getSubtype(self: RemoteObject, allocator: std.mem.Allocator) !?[]const u8 {
-        if (!c.v8_inspector__RemoteObject__hasSubtype(self.handle)) {
-            return null;
-        }
+        if (!c.v8_inspector__RemoteObject__hasSubtype(self.handle)) return null;
 
-        const csubtype = c.v8_inspector__RemoteObject__getSubtype(self.handle, &allocator);
-        if (CZigStringToString(csubtype)) |subtype| {
-            return subtype;
-        }
-        return error.V8AllocFailed;
+        var csubtype: c.CZigString = .{ .ptr = null, .len = 0 };
+        if (!c.v8_inspector__RemoteObject__getSubtype(self.handle, &allocator, &csubtype)) return error.V8AllocFailed;
+        return CZigStringToString(csubtype);
     }
     pub fn getClassName(self: RemoteObject, allocator: std.mem.Allocator) !?[]const u8 {
-        if (!c.v8_inspector__RemoteObject__hasClassName(self.handle)) {
-            return null;
-        }
+        if (!c.v8_inspector__RemoteObject__hasClassName(self.handle)) return null;
 
-        const cclass_name = c.v8_inspector__RemoteObject__getClassName(self.handle, &allocator);
-        if (CZigStringToString(cclass_name)) |class_name| {
-            return class_name;
-        }
-        return error.V8AllocFailed;
+        var cclass_name: c.CZigString = .{ .ptr = null, .len = 0 };
+        if (!c.v8_inspector__RemoteObject__getClassName(self.handle, &allocator, &cclass_name)) return error.V8AllocFailed;
+        return CZigStringToString(cclass_name);
     }
     pub fn getDescription(self: RemoteObject, allocator: std.mem.Allocator) !?[]const u8 {
-        if (!c.v8_inspector__RemoteObject__hasDescription(self.handle)) {
-            return null;
-        }
+        if (!c.v8_inspector__RemoteObject__hasDescription(self.handle)) return null;
 
-        const cdescription = c.v8_inspector__RemoteObject__getDescription(self.handle, &allocator);
-        if (CZigStringToString(cdescription)) |description| {
-            return description;
-        }
-        return error.V8AllocFailed;
+        var description: c.CZigString = .{ .ptr = null, .len = 0 };
+        if (!c.v8_inspector__RemoteObject__getDescription(self.handle, &allocator, &description)) return error.V8AllocFailed;
+        return CZigStringToString(description);
     }
     pub fn getObjectId(self: RemoteObject, allocator: std.mem.Allocator) !?[]const u8 {
-        if (!c.v8_inspector__RemoteObject__hasObjectId(self.handle)) {
-            return null;
-        }
+        if (!c.v8_inspector__RemoteObject__hasObjectId(self.handle)) return null;
 
-        const cobject_id = c.v8_inspector__RemoteObject__getObjectId(self.handle, &allocator);
-        if (CZigStringToString(cobject_id)) |object_id| {
-            return object_id;
-        }
-        return error.V8AllocFailed;
+        var cobject_id: c.CZigString = .{ .ptr = null, .len = 0 };
+        if (!c.v8_inspector__RemoteObject__getObjectId(self.handle, &allocator, &cobject_id)) return error.V8AllocFailed;
+        return CZigStringToString(cobject_id);
     }
 };
 

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -2777,61 +2777,56 @@ pub const RemoteObject = struct {
         c.v8_inspector__RemoteObject__DELETE(self.handle);
     }
 
-    pub fn getType(self: RemoteObject, allocator: std.mem.Allocator) ![:0]const u8 {
-        const type_ = c.v8_inspector__RemoteObject__getType(self.handle, &allocator);
-        if (type_ == null) {
-            return error.V8AllocFailed;
+    pub fn getType(self: RemoteObject, allocator: std.mem.Allocator) ![]const u8 {
+        const ctype_ = c.v8_inspector__RemoteObject__getType(self.handle, &allocator);
+        if (CZigStringToString(ctype_)) |type_| {
+            return type_;
         }
-        const idx = std.mem.indexOfSentinel(u8, 0, type_);
-        return type_[0..idx :0];
+        return error.V8AllocFailed;
     }
-    pub fn getSubtype(self: RemoteObject, allocator: std.mem.Allocator) !?[:0]const u8 {
+    pub fn getSubtype(self: RemoteObject, allocator: std.mem.Allocator) !?[]const u8 {
         if (!c.v8_inspector__RemoteObject__hasSubtype(self.handle)) {
             return null;
         }
 
-        const subtype = c.v8_inspector__RemoteObject__getSubtype(self.handle, &allocator);
-        if (subtype == null) {
-            return error.V8AllocFailed;
+        const csubtype = c.v8_inspector__RemoteObject__getSubtype(self.handle, &allocator);
+        if (CZigStringToString(csubtype)) |subtype| {
+            return subtype;
         }
-        const idx = std.mem.indexOfSentinel(u8, 0, subtype);
-        return subtype[0..idx :0];
+        return error.V8AllocFailed;
     }
-    pub fn getClassName(self: RemoteObject, allocator: std.mem.Allocator) !?[:0]const u8 {
+    pub fn getClassName(self: RemoteObject, allocator: std.mem.Allocator) !?[]const u8 {
         if (!c.v8_inspector__RemoteObject__hasClassName(self.handle)) {
             return null;
         }
 
-        const class_name = c.v8_inspector__RemoteObject__getClassName(self.handle, &allocator);
-        if (class_name == null) {
-            return error.V8AllocFailed;
+        const cclass_name = c.v8_inspector__RemoteObject__getClassName(self.handle, &allocator);
+        if (CZigStringToString(cclass_name)) |class_name| {
+            return class_name;
         }
-        const idx = std.mem.indexOfSentinel(u8, 0, class_name);
-        return class_name[0..idx :0];
+        return error.V8AllocFailed;
     }
-    pub fn getDescription(self: RemoteObject, allocator: std.mem.Allocator) !?[:0]const u8 {
+    pub fn getDescription(self: RemoteObject, allocator: std.mem.Allocator) !?[]const u8 {
         if (!c.v8_inspector__RemoteObject__hasDescription(self.handle)) {
             return null;
         }
 
-        const description = c.v8_inspector__RemoteObject__getDescription(self.handle, &allocator);
-        if (description == null) {
-            return error.V8AllocFailed;
+        const cdescription = c.v8_inspector__RemoteObject__getDescription(self.handle, &allocator);
+        if (CZigStringToString(cdescription)) |description| {
+            return description;
         }
-        const idx = std.mem.indexOfSentinel(u8, 0, description);
-        return description[0..idx :0];
+        return error.V8AllocFailed;
     }
-    pub fn getObjectId(self: RemoteObject, allocator: std.mem.Allocator) !?[:0]const u8 {
+    pub fn getObjectId(self: RemoteObject, allocator: std.mem.Allocator) !?[]const u8 {
         if (!c.v8_inspector__RemoteObject__hasObjectId(self.handle)) {
             return null;
         }
 
-        const object_id = c.v8_inspector__RemoteObject__getObjectId(self.handle, &allocator);
-        if (object_id == null) {
-            return error.V8AllocFailed;
+        const cobject_id = c.v8_inspector__RemoteObject__getObjectId(self.handle, &allocator);
+        if (CZigStringToString(cobject_id)) |object_id| {
+            return object_id;
         }
-        const idx = std.mem.indexOfSentinel(u8, 0, object_id);
-        return object_id[0..idx :0];
+        return error.V8AllocFailed;
     }
 };
 

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -2720,27 +2720,27 @@ pub const InspectorSession = struct {
         return RemoteObject{ .handle = remote_object };
     }
 
-    pub fn unwrapObject(self: InspectorSession, allocator: std.mem.Allocator, objectId: []const u8) !UnwrappedObject {
-        const in_objectId = c.CZigString{
-            .ptr = objectId.ptr,
-            .len = objectId.len,
+    pub fn unwrapObject(self: InspectorSession, allocator: std.mem.Allocator, object_id: []const u8) !UnwrappedObject {
+        const in_object_id = c.CZigString{
+            .ptr = object_id.ptr,
+            .len = object_id.len,
         };
         var out_error: c.CZigString = .{ .ptr = null, .len = 0 };
         var out_value_handle: ?*c.Value = null;
         var out_context_handle: ?*c.Context = null;
-        var out_objectGroup: c.CZigString = .{ .ptr = null, .len = 0 };
+        var out_object_group: c.CZigString = .{ .ptr = null, .len = 0 };
 
         const result = c.v8_inspector__Session__unwrapObject(
             self.handle,
             &allocator,
             &out_error,
-            in_objectId,
+            in_object_id,
             &out_value_handle,
             &out_context_handle,
-            &out_objectGroup,
+            &out_object_group,
         );
         if (!result) {
-            if (CZigStringToString(out_error)) |err| {
+            if (cZigStringToString(out_error)) |err| {
                 if (std.mem.eql(u8, err, "Invalid remote object id")) return error.InvalidRemoteObjectId;
                 if (std.mem.eql(u8, err, "Cannot find context with specified id")) return error.CannotFindContextWithSpecifiedId;
                 if (std.mem.eql(u8, err, "Could not find object with given id")) return error.CouldNotFindObjectWithGivenId;
@@ -2751,19 +2751,19 @@ pub const InspectorSession = struct {
         return .{
             .value = Value{ .handle = out_value_handle.? },
             .context = Context{ .handle = out_context_handle.? },
-            .objectGroup = CZigStringToString(out_objectGroup),
+            .object_group = cZigStringToString(out_object_group),
         };
     }
 };
 
-pub fn CZigStringToString(slice: c.CZigString) ?[]const u8 {
+pub fn cZigStringToString(slice: c.CZigString) ?[]const u8 {
     return if (slice.ptr == null) null else slice.ptr[0..slice.len];
 }
 
 pub const UnwrappedObject = struct {
     value: Value,
     context: Context,
-    objectGroup: ?[]const u8,
+    object_group: ?[]const u8,
 };
 
 /// Note: Some getters return owned memory (strings), while others return memory owned by V8 (objects).
@@ -2780,35 +2780,35 @@ pub const RemoteObject = struct {
     pub fn getType(self: RemoteObject, allocator: std.mem.Allocator) ![]const u8 {
         var ctype_: c.CZigString = .{ .ptr = null, .len = 0 };
         if (!c.v8_inspector__RemoteObject__getType(self.handle, &allocator, &ctype_)) return error.V8AllocFailed;
-        return CZigStringToString(ctype_) orelse return error.InvalidType;
+        return cZigStringToString(ctype_) orelse return error.InvalidType;
     }
     pub fn getSubtype(self: RemoteObject, allocator: std.mem.Allocator) !?[]const u8 {
         if (!c.v8_inspector__RemoteObject__hasSubtype(self.handle)) return null;
 
         var csubtype: c.CZigString = .{ .ptr = null, .len = 0 };
         if (!c.v8_inspector__RemoteObject__getSubtype(self.handle, &allocator, &csubtype)) return error.V8AllocFailed;
-        return CZigStringToString(csubtype);
+        return cZigStringToString(csubtype);
     }
     pub fn getClassName(self: RemoteObject, allocator: std.mem.Allocator) !?[]const u8 {
         if (!c.v8_inspector__RemoteObject__hasClassName(self.handle)) return null;
 
         var cclass_name: c.CZigString = .{ .ptr = null, .len = 0 };
         if (!c.v8_inspector__RemoteObject__getClassName(self.handle, &allocator, &cclass_name)) return error.V8AllocFailed;
-        return CZigStringToString(cclass_name);
+        return cZigStringToString(cclass_name);
     }
     pub fn getDescription(self: RemoteObject, allocator: std.mem.Allocator) !?[]const u8 {
         if (!c.v8_inspector__RemoteObject__hasDescription(self.handle)) return null;
 
         var description: c.CZigString = .{ .ptr = null, .len = 0 };
         if (!c.v8_inspector__RemoteObject__getDescription(self.handle, &allocator, &description)) return error.V8AllocFailed;
-        return CZigStringToString(description);
+        return cZigStringToString(description);
     }
     pub fn getObjectId(self: RemoteObject, allocator: std.mem.Allocator) !?[]const u8 {
         if (!c.v8_inspector__RemoteObject__hasObjectId(self.handle)) return null;
 
         var cobject_id: c.CZigString = .{ .ptr = null, .len = 0 };
         if (!c.v8_inspector__RemoteObject__getObjectId(self.handle, &allocator, &cobject_id)) return error.V8AllocFailed;
-        return CZigStringToString(cobject_id);
+        return cZigStringToString(cobject_id);
     }
 };
 


### PR DESCRIPTION
Builds on: https://github.com/lightpanda-io/zig-v8-fork/pull/51
To cleanup string passing also for wrapObject
- Fixes pointer issues where the description would point to the previous member if it was an empty string