### PR TITLE
contex_id

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1682,10 +1682,6 @@ void v8_inspector__Inspector__ContextCreated(v8_inspector::V8Inspector *self,
   self->contextCreated(info);
 }
 
-void v8_inspector__Inspector__resetContextGroup(v8_inspector::V8Inspector *self, int contextGroupId) {
-    self->resetContextGroup(contextGroupId);
-}
-
 // InspectorSession
 
 void v8_inspector__Session__DELETE(v8_inspector::V8InspectorSession* self) {

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -7,6 +7,7 @@
 #include "src/api/api.h"
 #include "src/inspector/protocol/Runtime.h"
 #include "src/inspector/v8-string-conversions.h"
+#include "src/debug/debug-interface.h"
 
 #include "inspector.h"
 
@@ -379,6 +380,10 @@ void v8__Context__SetEmbedderData(
         int idx,
         const v8::Value& val) {
     ptr_to_local(&self)->SetEmbedderData(idx, ptr_to_local(&val));
+}
+
+int v8__Context__DebugContextId(const v8::Context& self) {
+    return v8::debug::GetContextId(ptr_to_local(&self));
 }
 
 // ScriptOrigin
@@ -1675,6 +1680,10 @@ void v8_inspector__Inspector__ContextCreated(v8_inspector::V8Inspector *self,
 
   // call contextCreated
   self->contextCreated(info);
+}
+
+void v8_inspector__Inspector__resetContextGroup(v8_inspector::V8Inspector *self, int contextGroupId) {
+    self->resetContextGroup(contextGroupId);
 }
 
 // InspectorSession

--- a/src/binding.h
+++ b/src/binding.h
@@ -338,6 +338,7 @@ void v8__Context__SetEmbedderData(
     const Context* self,
     int idx,
     const Value* val);
+int v8__Context__DebugContextId(const Context* self);
 
 // Boolean
 const Boolean* v8__Boolean__New(
@@ -1063,6 +1064,7 @@ void v8_inspector__Inspector__ContextCreated(Inspector *self, const char *name,
                                              const char *auxData, const usize auxData_len,
                                              int contextGroupId,
     const Context* context);
+void v8_inspector__Inspector__resetContextGroup(Inspector *self, int contextGroupId) ;
 
 // RemoteObject
 void v8_inspector__RemoteObject__DELETE(RemoteObject *self);

--- a/src/binding.h
+++ b/src/binding.h
@@ -1064,7 +1064,6 @@ void v8_inspector__Inspector__ContextCreated(Inspector *self, const char *name,
                                              const char *auxData, const usize auxData_len,
                                              int contextGroupId,
     const Context* context);
-void v8_inspector__Inspector__resetContextGroup(Inspector *self, int contextGroupId) ;
 
 // RemoteObject
 void v8_inspector__RemoteObject__DELETE(RemoteObject *self);

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -557,6 +557,10 @@ pub const Context = struct {
     pub fn setEmbedderData(self: Self, idx: u32, val: anytype) void {
         c.v8__Context__SetEmbedderData(self.handle, @as(c_int, @intCast(idx)), getValueHandle(val));
     }
+
+    pub fn debugContextId(self: Self) i32 {
+        return c.v8__Context__DebugContextId(self.handle);
+    }
 };
 
 pub const PropertyCallbackInfo = struct {
@@ -2498,6 +2502,12 @@ pub const Inspector = struct {
             ctx.handle,
         );
         self.ctx_handle = ctx.handle;
+    }
+
+    pub fn resetContextGroup(
+        self: *Inspector,
+    ) void {
+        c.v8_inspector__Inspector__resetContextGroup(self.handle, contextGroupId);
     }
 };
 

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -2503,12 +2503,6 @@ pub const Inspector = struct {
         );
         self.ctx_handle = ctx.handle;
     }
-
-    pub fn resetContextGroup(
-        self: *Inspector,
-    ) void {
-        c.v8_inspector__Inspector__resetContextGroup(self.handle, contextGroupId);
-    }
 };
 
 // InspectorClient


### PR DESCRIPTION
RfC:
Currently exposes the contextId via the debugContextID() method, the debug prefix is used referencing the namespace it is from.
It is perhaps more fitting if we instead make this as part of the Inspector interface.  It is used there as `InspectedContext::contextId(context)`. However, that requires the caller to have the inspector as well as the context which just seems inconvenient.