### PR TITLE
expose v8.Object.Delete

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -981,6 +981,17 @@ void v8__Object__Set(
     );
 }
 
+void v8__Object__Delete(
+        const v8::Object& self,
+        const v8::Context& ctx,
+        const v8::Value& key,
+        v8::Maybe<bool>* out) {
+    *out = ptr_to_local(&self)->Delete(
+        ptr_to_local(&ctx),
+        ptr_to_local(&key)
+    );
+}
+
 void v8__Object__SetAtIndex(
         const v8::Object& self,
         const v8::Context& ctx,

--- a/src/binding.h
+++ b/src/binding.h
@@ -499,6 +499,11 @@ void v8__Object__Set(
     const Value* key,
     const Value* value,
     MaybeBool* out);
+void v8__Object__Delete(
+    const Object* self,
+    const Context* ctx,
+    const Value* key,
+    MaybeBool* out);
 void v8__Object__SetAtIndex(
     const Object* self,
     const Context* ctx,

--- a/src/main_build.zig
+++ b/src/main_build.zig
@@ -1,2 +1,1 @@
-pub fn main() !void {
-}
+pub fn main() !void {}

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -1004,7 +1004,7 @@ pub const ObjectTemplate = struct {
             .enumerator = configuration.enumerator orelse null,
             .definer = configuration.definer orelse null,
             .descriptor = configuration.descriptor orelse null,
-            .data = if (@typeInfo(@TypeOf(data)) == .@"null") null else getDataHandle(data),
+            .data = if (@typeInfo(@TypeOf(data)) == .null) null else getDataHandle(data),
             .flags = configuration.flags,
         };
         c.v8__ObjectTemplate__SetIndexedHandler(self.handle, &conf);
@@ -1019,7 +1019,7 @@ pub const ObjectTemplate = struct {
             .enumerator = configuration.enumerator orelse null,
             .definer = configuration.definer orelse null,
             .descriptor = configuration.descriptor orelse null,
-            .data = if (@typeInfo(@TypeOf(data)) == .@"null") null else getDataHandle(data),
+            .data = if (@typeInfo(@TypeOf(data)) == .null) null else getDataHandle(data),
             .flags = configuration.flags,
         };
         c.v8__ObjectTemplate__SetNamedHandler(self.handle, &conf);
@@ -1105,6 +1105,14 @@ pub const Object = struct {
     pub fn setValue(self: Self, ctx: Context, key: anytype, value: anytype) bool {
         var out: c.MaybeBool = undefined;
         c.v8__Object__Set(self.handle, ctx.handle, getValueHandle(key), getValueHandle(value), &out);
+        // Set only returns empty for an error or true.
+        return out.has_value;
+    }
+
+    // Returns true on success, false on fail.
+    pub fn deleteValue(self: Self, ctx: Context, key: anytype) bool {
+        var out: c.MaybeBool = undefined;
+        c.v8__Object__Delete(self.handle, ctx.handle, getValueHandle(key), &out);
         // Set only returns empty for an error or true.
         return out.has_value;
     }


### PR DESCRIPTION
Needed to delete the default "console" that V8 adds to the `Context`, so that we can inject our own.