### PR TITLE
Embed ICU into libc_v8.a and expose InitializeICU calls

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -133,6 +133,8 @@ fn createV8_Build(b: *std.Build, target: std.Build.ResolvedTarget, mode: std.bui
     if (!icu) {
         // Don't add i18n for now. It has a large dependency on third_party/icu.
         try gn_args.append("v8_enable_i18n_support=false");
+    } else {
+        try gn_args.append("icu_use_data_file=false");
     }
 
     if (mode != .Debug) {

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -162,6 +162,8 @@ void v8__V8__InitializePlatform(v8::Platform* platform) {
 
 void v8__V8__Initialize() { v8::V8::Initialize(); }
 
+bool v8__V8__InitializeICU() { return v8::V8::InitializeICU(); }
+
 int v8__V8__Dispose() { return v8::V8::Dispose(); }
 
 void v8__V8__DisposePlatform() { v8::V8::DisposePlatform(); }

--- a/src/binding.h
+++ b/src/binding.h
@@ -128,6 +128,7 @@ const Uint8Array* v8__Uint8Array__New(
 // V8
 void v8__V8__InitializePlatform(Platform* platform);
 void v8__V8__Initialize();
+bool v8__V8__InitializeICU();
 int v8__V8__Dispose();
 void v8__V8__DisposePlatform();
 const char* v8__V8__GetVersion();

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -172,6 +172,12 @@ pub fn initV8() void {
 }
 
 /// [v8]
+/// Initializes the ICU bundled with v8.
+pub fn initV8ICU() bool {
+    return c.v8__V8__InitializeICU();
+}
+
+/// [v8]
 /// Releases any resources used by v8 and stops any utility thread
 /// that may be running.  Note that disposing v8 is permanent, it
 /// cannot be reinitialized.


### PR DESCRIPTION
Not sure if it completely fixes the crashes when trying to use ICU from v8, but at least simple things, like `new Intl.DateTimeFormat()` no longer crash.