### PR TITLE
Expose Isolate's SetHostInitializeImportMetaObjectCallback

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -303,6 +303,12 @@ void v8__Isolate__SetHostImportModuleDynamicallyCallback(
     isolate->SetHostImportModuleDynamicallyCallback(callback);
 }
 
+void v8__Isolate__SetHostInitializeImportMetaObjectCallback(
+        v8::Isolate* isolate,
+        v8::HostInitializeImportMetaObjectCallback callback) {
+    isolate->SetHostInitializeImportMetaObjectCallback(callback);
+}
+
 void v8__Isolate__SetPromiseRejectCallback(
         v8::Isolate* isolate,
         v8::PromiseRejectCallback callback) {

--- a/src/binding.h
+++ b/src/binding.h
@@ -77,6 +77,7 @@ typedef enum PromiseRejectEvent {
 typedef struct PromiseRejectMessage PromiseRejectMessage;
 typedef void (*PromiseRejectCallback)(PromiseRejectMessage);
 typedef Promise* (*HostImportModuleDynamicallyCallback)(Context*, Data*, Value*, String*, FixedArray*);
+typedef void (*HostInitializeImportMetaObjectCallback)(Context*, Module*, Data*);
 typedef enum MessageErrorLevel {
     kMessageLog = (1 << 0),
     kMessageDebug = (1 << 1),
@@ -215,6 +216,9 @@ const Value* v8__Isolate__ThrowException(
 void v8__Isolate__SetHostImportModuleDynamicallyCallback(
     Isolate* isolate,
     HostImportModuleDynamicallyCallback callback);
+void v8__Isolate__SetHostInitializeImportMetaObjectCallback(
+    Isolate* isolate,
+    HostInitializeImportMetaObjectCallback callback);
 void v8__Isolate__SetPromiseRejectCallback(
     Isolate* isolate,
     PromiseRejectCallback callback);

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -332,6 +332,15 @@ pub const Isolate = struct {
     }
 
     /// [V8]
+    /// Sets callback for the first time import.meta is called on a module
+    pub fn setHostInitializeImportMetaObjectCallback(
+        self: Self,
+        callback: c.HostInitializeImportMetaObjectCallback,
+    ) void {
+        c.v8__Isolate__SetHostInitializeImportMetaObjectCallback(self.handle, callback);
+    }
+
+    /// [V8]
     /// Set callback to notify about promise reject with no handler, or
     /// revocation of such a previous notification once the handler is added.
     pub fn setPromiseRejectCallback(self: Self, callback: c.PromiseRejectCallback) void {


### PR DESCRIPTION
The first time `import.meta` is called within a module, this callback is called and we can populate it with whatever fields we want. For WebAPI, the important field is `url`:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import.meta