### PR TITLE
Fix fetching of v8 build tools

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -51,7 +51,7 @@ pub fn build(b: *std.Build) !void {
             // trailing slash for rsync src is important, but Zig really doesn't
             // want to add it, so this is what I came up with.
             const build_tools = b.path("build-tools");
-            const build_tools_path = b.fmt("{any}/", .{build_tools.getPath3(b, null)});
+            const build_tools_path = b.fmt("{f}/", .{build_tools.getPath3(b, null)});
             var cp_build_files = b.addSystemCommand(&.{ "rsync", "-r", build_tools_path, "v8" });
             cp_build_files.setCwd(root_path);
             cp_build_files.step.dependOn(&mkdir_v8_dir.step);


### PR DESCRIPTION
This fixes the fetching of build tools for v8. The previous version would print the entire path struct which just wouldn't work. 