### PR TITLE
Add support for flags to build on iOS

### DIFF
--- a/build-tools/build_v8.sh
+++ b/build-tools/build_v8.sh
@@ -33,7 +33,7 @@ if [ "${OS}" = "linux" ] && [ "${ARCH}" == "arm64" ]; then
   EXTRA_ARGS="clang_base_path=\"/usr/lib/llvm-21\" clang_use_chrome_plugins=false treat_warnings_as_errors=false"
 fi
 if [ "${OS}" = "ios" ]; then
-  EXTRA_ARGS="v8_enable_pointer_compression=false v8_enable_webassembly=false"
+  EXTRA_ARGS="v8_enable_pointer_compression=false v8_enable_webassembly=false target_environment=${TARGET_ENVIRONMENT}"
 fi
 
 TARGET_ARCH=${ARCH}

--- a/build-tools/build_v8.sh
+++ b/build-tools/build_v8.sh
@@ -32,6 +32,9 @@ EXTRA_ARGS=""
 if [ "${OS}" = "linux" ] && [ "${ARCH}" == "arm64" ]; then
   EXTRA_ARGS="clang_base_path=\"/usr/lib/llvm-21\" clang_use_chrome_plugins=false treat_warnings_as_errors=false"
 fi
+if [ "${OS}" = "ios" ]; then
+  EXTRA_ARGS="v8_enable_pointer_compression=false v8_enable_webassembly=false"
+fi
 
 TARGET_ARCH=${ARCH}
 if [ "${ARCH}" = "amd64" ]; then

--- a/build-tools/build_v8.sh
+++ b/build-tools/build_v8.sh
@@ -33,7 +33,7 @@ if [ "${OS}" = "linux" ] && [ "${ARCH}" == "arm64" ]; then
   EXTRA_ARGS="clang_base_path=\"/usr/lib/llvm-21\" clang_use_chrome_plugins=false treat_warnings_as_errors=false"
 fi
 if [ "${OS}" = "ios" ]; then
-  EXTRA_ARGS="v8_enable_pointer_compression=false v8_enable_webassembly=false target_environment=${TARGET_ENVIRONMENT}"
+  EXTRA_ARGS="v8_enable_pointer_compression=false v8_enable_webassembly=false target_environment=\"${TARGET_ENVIRONMENT}\""
 fi
 
 TARGET_ARCH=${ARCH}

--- a/build-tools/utils.sh
+++ b/build-tools/utils.sh
@@ -23,8 +23,13 @@ case $(uname -m) in
   *)      fail "unsupported architecture: $(uname -m)"
 esac
 
-case "$OSTYPE" in
-  darwin*)  OS="mac" ;;
-  linux*)   OS="linux" ;;
-  *)        fail "unsupported platform: ${OSTYPE}"
+: "${OS:=unset}"
+case "$OS" in
+  unset)
+    case "$OSTYPE" in
+      darwin*)  OS="mac" ;;
+      linux*)   OS="linux" ;;
+      *)        fail "unsupported platform: ${OSTYPE}"
+    esac
+    ;;
 esac

--- a/build.zig
+++ b/build.zig
@@ -132,6 +132,7 @@ pub fn build(b: *std.Build) !void {
         const os = switch (target.result.os.tag) {
             .linux => "linux",
             .macos => "macos",
+            .ios => "ios",
             else => return error.UnsupportedPlatform,
         };
 


### PR DESCRIPTION
This enables v8 to be cross compiled for iOS.

`OS=ios` can be set in the environment before running `make build-v8`, and the correct extra args will be added.