### PR TITLE
Revert "fix constness"

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -454,8 +454,8 @@ const v8::ArrayBuffer* v8__ArrayBufferView__Buffer(const v8::ArrayBufferView& se
     return local_to_ptr(ptr_to_local(&self)->Buffer());
 }
 
-size_t v8__ArrayBufferView__ByteLength(const v8::ArrayBufferView& self) { return self.ByteLength(); }
-size_t v8__ArrayBufferView__ByteOffset(const v8::ArrayBufferView& self) { return self.ByteOffset(); }
+size_t v8__ArrayBufferView__ByteLength(v8::ArrayBufferView& self) { return self.ByteLength(); }
+size_t v8__ArrayBufferView__ByteOffset(v8::ArrayBufferView& self) { return self.ByteOffset(); }
 
 // HandleScope
 

--- a/src/binding.h
+++ b/src/binding.h
@@ -338,8 +338,8 @@ SharedPtr v8__ArrayBuffer__GetBackingStore(const ArrayBuffer* self);
 
 // ArrayBufferView
 const ArrayBuffer* v8__ArrayBufferView__Buffer(const ArrayBufferView* self);
-size_t v8__ArrayBufferView__ByteLength(const ArrayBufferView* self);
-size_t v8__ArrayBufferView__ByteOffset(const ArrayBufferView* self);
+size_t v8__ArrayBufferView__ByteLength(ArrayBufferView* self);
+size_t v8__ArrayBufferView__ByteOffset(ArrayBufferView* self);
 
 // HandleScope
 typedef struct HandleScope {


### PR DESCRIPTION
This reverts commit 4e4fdc834a50b9618b67686e46cb12e8ff11cd28.

I don't know why I was getting constness errors the other way before.