### PR TITLE
ci: stick setup-zig version to v2.0.5

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,7 +23,7 @@ jobs:
 
     runs-on: ubuntu-22.04
     steps:
-      - uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@v2.0.5
         with:
           version: ${{ env.ZIG_VERSION }}
           cache-key: ${{ env.ZIG_VERSION }}-${{ env.OS }}-${{ env.ARCH }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -33,6 +33,8 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - run: zig env
+
       - run: |
           sudo apt-get update
           sudo apt-get install -yq libglib2.0-dev


### PR DESCRIPTION
[setup-zig v2.1.0](https://github.com/mlugg/setup-zig/releases/tag/v2.1.0) breaks the build.