### PR TITLE
Misc Caching Changes

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,7 +13,7 @@ permissions:
 env:
   ZIG_VERSION: 0.15.1
   V8_REVISION: 14.0.365.4
-  LP_CACHE: ".lp-cache"
+  V8_CACHE_ROOT: ".v8-cache"
 
 jobs:
   build-x86_64-linux:
@@ -40,7 +40,7 @@ jobs:
           sudo apt-get install -yq libglib2.0-dev
 
       - run: zig build -Doptimize=ReleaseSafe build-v8
-      - run: mv ${{ env.LP_CACHE }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/release/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
+      - run: mv ${{ env.V8_CACHE_ROOT }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/release/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
 
       - name: Upload the build
         uses: ncipollo/release-action@v1
@@ -70,7 +70,7 @@ jobs:
           fetch-depth: 0
 
       - run: zig build -Doptimize=ReleaseSafe build-v8
-      - run: mv ${{ env.LP_CACHE }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/release/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
+      - run: mv ${{ env.V8_CACHE_ROOT }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/release/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
 
       - name: Upload the build
         uses: ncipollo/release-action@v1
@@ -105,7 +105,7 @@ jobs:
           sudo ln -nsf /usr/lib/llvm-21/lib/clang/21/lib/linux/ /usr/lib/llvm-21/lib/clang/21/lib/aarch64-unknown-linux-gnu
 
       - run: zig build -Doptimize=ReleaseSafe build-v8
-      - run: mv ${{ env.LP_CACHE }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/release/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
+      - run: mv ${{ env.V8_CACHE_ROOT }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/release/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
 
       - name: Upload the build
         uses: ncipollo/release-action@v1
@@ -135,7 +135,7 @@ jobs:
           fetch-depth: 0
 
       - run: zig build -Doptimize=ReleaseSafe build-v8
-      - run: mv ${{ env.LP_CACHE }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/release/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
+      - run: mv ${{ env.V8_CACHE_ROOT }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/release/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
 
       - name: Upload the build
         uses: ncipollo/release-action@v1
@@ -165,7 +165,7 @@ jobs:
           fetch-depth: 0
 
       - run: zig build -Doptimize=ReleaseSafe build-v8
-      - run: mv ${{ env.LP_CACHE }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/release/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
+      - run: mv ${{ env.V8_CACHE_ROOT }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/release/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
 
       - name: Upload the build
         uses: ncipollo/release-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.zig-cache/
-/.lp-cache/
+/.v8-cache/
 /zig-out/
 /v8/
 result

--- a/build.zig
+++ b/build.zig
@@ -25,7 +25,7 @@ pub fn build(b: *std.Build) !void {
 
     const cache_root = b.option([]const u8, "cache_root", "Root directory for the V8 and depot_tools cache") orelse b.pathFromRoot(".lp-cache");
     std.fs.cwd().access(cache_root, .{}) catch {
-        try std.fs.cwd().makeDir(cache_root);
+        try std.fs.cwd().makePath(cache_root);
     };
 
     const prebuilt_v8_path = b.option([]const u8, "prebuilt_v8_path", "Path to prebuilt libc_v8.a");

--- a/build.zig
+++ b/build.zig
@@ -23,15 +23,19 @@ pub fn build(b: *std.Build) !void {
         b.option(bool, "inspector_subtype", "Export default valueSubtype and descriptionForValueSubtype") orelse true,
     );
 
-    const cache_root = b.option([]const u8, "cache_root", "Root directory for the V8 and depot_tools cache") orelse b.pathFromRoot(".lp-cache");
-    std.fs.cwd().access(cache_root, .{}) catch {
-        try std.fs.cwd().makePath(cache_root);
+    const v8_cache_root = b.option(
+        []const u8,
+        "v8_cache_root",
+        "Root directory for the V8 and depot_tools cache, must be an absolute path.",
+    ) orelse b.pathFromRoot(".v8-cache");
+    std.fs.cwd().access(v8_cache_root, .{}) catch {
+        try std.fs.cwd().makePath(v8_cache_root);
     };
 
     const prebuilt_v8_path = b.option([]const u8, "prebuilt_v8_path", "Path to prebuilt libc_v8.a");
 
-    const v8_dir = b.fmt("{s}/v8-{s}", .{ cache_root, V8_VERSION });
-    const depot_tools_dir = b.fmt("{s}/depot_tools-{s}", .{ cache_root, V8_VERSION });
+    const v8_dir = b.fmt("{s}/v8-{s}", .{ v8_cache_root, V8_VERSION });
+    const depot_tools_dir = b.fmt("{s}/depot_tools-{s}", .{ v8_cache_root, V8_VERSION });
 
     const built_v8 = if (prebuilt_v8_path) |path| blk: {
         // Use prebuilt_v8 if available.


### PR DESCRIPTION
This uses the `makePath` instead of `makeDir` for ensuring the cache root exists, this allows you to pass in paths that need to be created. This also renames the caching to `v8_cache_root` because `cache_root` feels very ambiguous.