### PR TITLE
Expose v8::Global

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1570,6 +1570,31 @@ void v8__Persistent__SetWeakFinalizer(
     self->SetWeak(finalizer_ctx, finalizer_cb, type);
 }
 
+// Global
+
+void v8__Global__New(
+        v8::Isolate* isolate,
+        const v8::Data& data,
+        v8::Global<v8::Data>* out) {
+    new (out) v8::Global<v8::Data>(isolate, ptr_to_local(&data));
+}
+
+void v8__Global__Reset(v8::Global<v8::Data>* self) {
+    self->Reset();
+}
+
+void v8__Global__SetWeak(v8::Global<v8::Data>* self) {
+    self->SetWeak();
+}
+
+void v8__Global__SetWeakFinalizer(
+        v8::Global<v8::Data>* self,
+        void* finalizer_ctx,
+        v8::WeakCallbackInfo<void>::Callback finalizer_cb,
+        v8::WeakCallbackType type) {
+    self->SetWeak(finalizer_ctx, finalizer_cb, type);
+}
+
 // WeakCallbackInfo
 
 v8::Isolate* v8__WeakCallbackInfo__GetIsolate(

--- a/src/binding.h
+++ b/src/binding.h
@@ -861,6 +861,24 @@ void v8__Persistent__SetWeakFinalizer(
     WeakCallback finalizer_cb,
     WeakCallbackType type);
 
+// Global
+typedef struct Global {
+    uintptr_t data_ptr;
+} Global;
+void v8__Global__New(
+    Isolate* isolate,
+    const Data* data,
+    Global* out);
+void v8__Global__Reset(
+    Global* self);
+void v8__Global__SetWeak(
+    Global* self);
+void v8__Global__SetWeakFinalizer(
+    Global* self,
+    void* finalizer_ctx,
+    WeakCallback finalizer_cb,
+    WeakCallbackType type);
+
 // WeakCallbackInfo
 Isolate* v8__WeakCallbackInfo__GetIsolate(const WeakCallbackInfo* self);
 void* v8__WeakCallbackInfo__GetParameter(const WeakCallbackInfo* self);


### PR DESCRIPTION
My understanding is that v8::Global is the new (2016?) and "better" way to have control over a v8 value's lifetime. v8::Global is "better" because it's moveable (whereas Persistent is copyable).

Now, for Zig/C, it really doesn't matter. The two are essentially the same. We could keep using Persistent, but Global is the recommended class. I imagine it's more likely to see updates / improvements. Since I'm reworking v8 integration a little, this seems like a good time to do it.