### PR TITLE
Direct v8

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -290,6 +290,10 @@ const v8::Context* v8__Isolate__GetCurrentContext(v8::Isolate* isolate) {
     return local_to_ptr(isolate->GetCurrentContext());
 }
 
+int v8__Isolate__ContextDisposedNotification(v8::Isolate* isolate) {
+    return isolate->ContextDisposedNotification();
+}
+
 size_t v8__Isolate__CreateParams__SIZEOF() {
     return sizeof(v8::Isolate::CreateParams);
 }

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1575,6 +1575,31 @@ void v8__Persistent__SetWeakFinalizer(
     self->SetWeak(finalizer_ctx, finalizer_cb, type);
 }
 
+// Global
+
+void v8__Global__New(
+        v8::Isolate* isolate,
+        const v8::Data& data,
+        v8::Global<v8::Data>* out) {
+    new (out) v8::Global<v8::Data>(isolate, ptr_to_local(&data));
+}
+
+void v8__Global__Reset(v8::Global<v8::Data>* self) {
+    self->Reset();
+}
+
+void v8__Global__SetWeak(v8::Global<v8::Data>* self) {
+    self->SetWeak();
+}
+
+void v8__Global__SetWeakFinalizer(
+        v8::Global<v8::Data>* self,
+        void* finalizer_ctx,
+        v8::WeakCallbackInfo<void>::Callback finalizer_cb,
+        v8::WeakCallbackType type) {
+    self->SetWeak(finalizer_ctx, finalizer_cb, type);
+}
+
 // WeakCallbackInfo
 
 v8::Isolate* v8__WeakCallbackInfo__GetIsolate(

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1604,6 +1604,21 @@ void v8__Global__SetWeakFinalizer(
     self->SetWeak(finalizer_ctx, finalizer_cb, type);
 }
 
+// Eternal
+
+void v8__Eternal__New(
+        v8::Isolate* isolate,
+        const v8::Data& data,
+        v8::Eternal<v8::Data>* out) {
+    new (out) v8::Eternal<v8::Data>(isolate, ptr_to_local(&data));
+}
+
+const v8::Data* v8__Eternal__Get(
+        v8::Eternal<v8::Data>* self,
+        v8::Isolate* isolate) {
+    return local_to_ptr(self->Get(isolate));
+}
+
 // WeakCallbackInfo
 
 v8::Isolate* v8__WeakCallbackInfo__GetIsolate(

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1604,7 +1604,7 @@ void v8__Global__SetWeakFinalizer(
     self->SetWeak(finalizer_ctx, finalizer_cb, type);
 }
 const v8::Data* v8__Global__Get(
-        v8::Global<v8::Data>* self,
+        const v8::Global<v8::Data>* self,
         v8::Isolate* isolate) {
     return local_to_ptr(self->Get(isolate));
 }
@@ -1619,7 +1619,7 @@ void v8__Eternal__New(
 }
 
 const v8::Data* v8__Eternal__Get(
-        v8::Eternal<v8::Data>* self,
+        const v8::Eternal<v8::Data>* self,
         v8::Isolate* isolate) {
     return local_to_ptr(self->Get(isolate));
 }

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -2352,4 +2352,8 @@ bool v8__StartupData__IsValid(v8::StartupData self) {
     return self.IsValid();
 }
 
+void v8__StartupData__DELETE(const char* data) {
+    delete[] data;
+}
+
 } // extern "C"

--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1603,6 +1603,11 @@ void v8__Global__SetWeakFinalizer(
         v8::WeakCallbackType type) {
     self->SetWeak(finalizer_ctx, finalizer_cb, type);
 }
+const v8::Data* v8__Global__Get(
+        v8::Global<v8::Data>* self,
+        v8::Isolate* isolate) {
+    return local_to_ptr(self->Get(isolate));
+}
 
 // Eternal
 

--- a/src/binding.h
+++ b/src/binding.h
@@ -10,10 +10,10 @@ typedef struct Isolate Isolate;
 typedef struct StackTrace StackTrace;
 typedef struct StackFrame StackFrame;
 typedef struct FixedArray FixedArray;
-typedef struct Module Module;
+typedef struct Data Module;
 typedef struct FunctionTemplate FunctionTemplate;
 typedef struct Message Message;
-typedef struct Context Context;
+typedef struct Data Context;
 // Internally, all Value types have a base InternalAddress struct.
 typedef uintptr_t InternalAddress;
 // Super type.
@@ -411,7 +411,6 @@ bool v8__StackFrame__IsWasm(const StackFrame* self);
 bool v8__StackFrame__IsUserJavaScript(const StackFrame* self);
 
 // Context
-typedef struct Context Context;
 typedef struct ObjectTemplate ObjectTemplate;
 Context* v8__Context__New(Isolate* isolate, const ObjectTemplate* global_tmpl, const Value* global_obj);
 Context* v8__Context__FromSnapshot(Isolate*, size_t);

--- a/src/binding.h
+++ b/src/binding.h
@@ -880,6 +880,9 @@ void v8__Global__SetWeakFinalizer(
     void* finalizer_ctx,
     WeakCallback finalizer_cb,
     WeakCallbackType type);
+const Data* v8__Global__Get(
+    Global* self,
+    Isolate* isolate);
 
 // Eternal
 typedef struct Eternal {

--- a/src/binding.h
+++ b/src/binding.h
@@ -1304,3 +1304,4 @@ size_t v8__SnapshotCreator__AddData2(SnapshotCreator*, const Context* ctx, const
 StartupData v8__SnapshotCreator__createBlob(SnapshotCreator*, FunctionCodeHandling);
 void v8__SnapshotCreator__DESTRUCT(SnapshotCreator*);
 bool v8__StartupData__IsValid(StartupData);
+void v8__StartupData__DELETE(const char* data);

--- a/src/binding.h
+++ b/src/binding.h
@@ -881,7 +881,7 @@ void v8__Global__SetWeakFinalizer(
     WeakCallback finalizer_cb,
     WeakCallbackType type);
 const Data* v8__Global__Get(
-    Global* self,
+    const Global* self,
     Isolate* isolate);
 
 // Eternal
@@ -893,7 +893,7 @@ void v8__Eternal__New(
     const Data* data,
     Eternal* out);
 const Data* v8__Eternal__Get(
-    Eternal* self,
+    const Eternal* self,
     Isolate* isolate);
 
 // WeakCallbackInfo

--- a/src/binding.h
+++ b/src/binding.h
@@ -863,6 +863,24 @@ void v8__Persistent__SetWeakFinalizer(
     WeakCallback finalizer_cb,
     WeakCallbackType type);
 
+// Global
+typedef struct Global {
+    uintptr_t data_ptr;
+} Global;
+void v8__Global__New(
+    Isolate* isolate,
+    const Data* data,
+    Global* out);
+void v8__Global__Reset(
+    Global* self);
+void v8__Global__SetWeak(
+    Global* self);
+void v8__Global__SetWeakFinalizer(
+    Global* self,
+    void* finalizer_ctx,
+    WeakCallback finalizer_cb,
+    WeakCallbackType type);
+
 // WeakCallbackInfo
 Isolate* v8__WeakCallbackInfo__GetIsolate(const WeakCallbackInfo* self);
 void* v8__WeakCallbackInfo__GetParameter(const WeakCallbackInfo* self);

--- a/src/binding.h
+++ b/src/binding.h
@@ -217,6 +217,7 @@ Context* v8__Isolate__GetCurrentContext(Isolate* isolate);
 const Value* v8__Isolate__ThrowException(
     Isolate* isolate,
     const Value* exception);
+int v8__Isolate__ContextDisposedNotification(Isolate* isolate);
 void v8__Isolate__SetHostImportModuleDynamicallyCallback(
     Isolate* isolate,
     HostImportModuleDynamicallyCallback callback);

--- a/src/binding.h
+++ b/src/binding.h
@@ -881,6 +881,18 @@ void v8__Global__SetWeakFinalizer(
     WeakCallback finalizer_cb,
     WeakCallbackType type);
 
+// Eternal
+typedef struct Eternal {
+    uintptr_t data_ptr;
+} Eternal;
+void v8__Eternal__New(
+    Isolate* isolate,
+    const Data* data,
+    Eternal* out);
+const Data* v8__Eternal__Get(
+    Eternal* self,
+    Isolate* isolate);
+
 // WeakCallbackInfo
 Isolate* v8__WeakCallbackInfo__GetIsolate(const WeakCallbackInfo* self);
 void* v8__WeakCallbackInfo__GetParameter(const WeakCallbackInfo* self);

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -2902,67 +2902,67 @@ pub const InspectorClient = struct {
     }
 };
 
-pub export fn v8_inspector__Client__IMPL__generateUniqueId(
-    _: *c.InspectorClientImpl,
-    data: *anyopaque,
-) callconv(.c) i64 {
-    const inspector = Inspector.fromData(data);
-    return inspector.rnd.random().int(i64);
-}
+// pub export fn v8_inspector__Client__IMPL__generateUniqueId(
+//     _: *c.InspectorClientImpl,
+//     data: *anyopaque,
+// ) callconv(.c) i64 {
+//     const inspector = Inspector.fromData(data);
+//     return inspector.rnd.random().int(i64);
+// }
 
-pub export fn v8_inspector__Client__IMPL__runMessageLoopOnPause(
-    _: *c.InspectorClientImpl,
-    data: *anyopaque,
-    contextGroupId: c_int,
-) callconv(.c) void {
-    const inspector = Inspector.fromData(data);
-    inspector.channel.onRunMessageLoopOnPause(inspector.channel.ctx, @intCast(contextGroupId));
-}
+// pub export fn v8_inspector__Client__IMPL__runMessageLoopOnPause(
+//     _: *c.InspectorClientImpl,
+//     data: *anyopaque,
+//     contextGroupId: c_int,
+// ) callconv(.c) void {
+//     const inspector = Inspector.fromData(data);
+//     inspector.channel.onRunMessageLoopOnPause(inspector.channel.ctx, @intCast(contextGroupId));
+// }
 
-pub export fn v8_inspector__Client__IMPL__quitMessageLoopOnPause(
-    _: *c.InspectorClientImpl,
-    data: *anyopaque,
-) callconv(.c) void {
-    const inspector = Inspector.fromData(data);
-    inspector.channel.onQuitMessageLoopOnPause(inspector.channel.ctx);
-}
+// pub export fn v8_inspector__Client__IMPL__quitMessageLoopOnPause(
+//     _: *c.InspectorClientImpl,
+//     data: *anyopaque,
+// ) callconv(.c) void {
+//     const inspector = Inspector.fromData(data);
+//     inspector.channel.onQuitMessageLoopOnPause(inspector.channel.ctx);
+// }
 
-pub export fn v8_inspector__Client__IMPL__runIfWaitingForDebugger(
-    _: *c.InspectorClientImpl,
-    data: *anyopaque,
-    contextGroupId: c_int,
-) callconv(.c) void {
-    _ = contextGroupId;
-    const inspector = Inspector.fromData(data);
-    _ = inspector;
-    // TODO
-}
+// pub export fn v8_inspector__Client__IMPL__runIfWaitingForDebugger(
+//     _: *c.InspectorClientImpl,
+//     data: *anyopaque,
+//     contextGroupId: c_int,
+// ) callconv(.c) void {
+//     _ = contextGroupId;
+//     const inspector = Inspector.fromData(data);
+//     _ = inspector;
+//     // TODO
+// }
 
-// TODO: move params to C types
-pub export fn v8_inspector__Client__IMPL__consoleAPIMessage(
-    _: *c.InspectorClientImpl,
-    data: *anyopaque,
-    contextGroupId: c_int,
-    _: c.MessageErrorLevel,
-    _: *c.StringView,
-    _: *c.StringView,
-    _: c_uint,
-    _: c_uint,
-    _: *c.StackTrace,
-) callconv(.c) void {
-    _ = contextGroupId;
-    const inspector = Inspector.fromData(data);
-    _ = inspector;
-    // TODO
-}
+// // TODO: move params to C types
+// pub export fn v8_inspector__Client__IMPL__consoleAPIMessage(
+//     _: *c.InspectorClientImpl,
+//     data: *anyopaque,
+//     contextGroupId: c_int,
+//     _: c.MessageErrorLevel,
+//     _: *c.StringView,
+//     _: *c.StringView,
+//     _: c_uint,
+//     _: c_uint,
+//     _: *c.StackTrace,
+// ) callconv(.c) void {
+//     _ = contextGroupId;
+//     const inspector = Inspector.fromData(data);
+//     _ = inspector;
+//     // TODO
+// }
 
-pub export fn v8_inspector__Client__IMPL__ensureDefaultContextInGroup(
-    _: *c.InspectorClientImpl,
-    data: *anyopaque,
-) callconv(.c) ?*const C_Context {
-    const inspector = Inspector.fromData(data);
-    return inspector.ctx_handle;
-}
+// pub export fn v8_inspector__Client__IMPL__ensureDefaultContextInGroup(
+//     _: *c.InspectorClientImpl,
+//     data: *anyopaque,
+// ) callconv(.c) ?*const C_Context {
+//     const inspector = Inspector.fromData(data);
+//     return inspector.ctx_handle;
+// }
 
 comptime {
     if (@import("default_exports").inspector_subtype) {
@@ -3023,35 +3023,35 @@ pub const InspectorChannel = struct {
     }
 };
 
-pub export fn v8_inspector__Channel__IMPL__sendResponse(
-    _: *c.InspectorChannelImpl,
-    data: *anyopaque,
-    call_id: c_int,
-    msg: [*c]u8,
-    length: usize,
-) callconv(.c) void {
-    const inspector = Inspector.fromData(data);
-    inspector.channel.resp(@as(u32, @intCast(call_id)), msg[0..length]);
-}
+// pub export fn v8_inspector__Channel__IMPL__sendResponse(
+//     _: *c.InspectorChannelImpl,
+//     data: *anyopaque,
+//     call_id: c_int,
+//     msg: [*c]u8,
+//     length: usize,
+// ) callconv(.c) void {
+//     const inspector = Inspector.fromData(data);
+//     inspector.channel.resp(@as(u32, @intCast(call_id)), msg[0..length]);
+// }
 
-pub export fn v8_inspector__Channel__IMPL__sendNotification(
-    _: *c.InspectorChannelImpl,
-    data: *anyopaque,
-    msg: [*c]u8,
-    length: usize,
-) callconv(.c) void {
-    const inspector = Inspector.fromData(data);
-    inspector.channel.notif(msg[0..length]);
-}
+// pub export fn v8_inspector__Channel__IMPL__sendNotification(
+//     _: *c.InspectorChannelImpl,
+//     data: *anyopaque,
+//     msg: [*c]u8,
+//     length: usize,
+// ) callconv(.c) void {
+//     const inspector = Inspector.fromData(data);
+//     inspector.channel.notif(msg[0..length]);
+// }
 
-pub export fn v8_inspector__Channel__IMPL__flushProtocolNotifications(
-    _: *c.InspectorChannelImpl,
-    data: *anyopaque,
-) callconv(.c) void {
-    const inspector = Inspector.fromData(data);
-    _ = inspector;
-    // TODO
-}
+// pub export fn v8_inspector__Channel__IMPL__flushProtocolNotifications(
+//     _: *c.InspectorChannelImpl,
+//     data: *anyopaque,
+// ) callconv(.c) void {
+//     const inspector = Inspector.fromData(data);
+//     _ = inspector;
+//     // TODO
+// }
 
 // InspectorSession
 
@@ -3233,12 +3233,12 @@ pub const RemoteObject = struct {
     }
 };
 
-/// Enables C to allocate using the given Zig allocator
-pub export fn zigAlloc(self: *anyopaque, bytes: usize) callconv(.c) ?[*]u8 {
-    const allocator: *std.mem.Allocator = @ptrCast(@alignCast(self));
-    const allocated_bytes = allocator.alloc(u8, bytes) catch return null;
-    return allocated_bytes.ptr;
-}
+// /// Enables C to allocate using the given Zig allocator
+// pub export fn zigAlloc(self: *anyopaque, bytes: usize) callconv(.c) ?[*]u8 {
+//     const allocator: *std.mem.Allocator = @ptrCast(@alignCast(self));
+//     const allocated_bytes = allocator.alloc(u8, bytes) catch return null;
+//     return allocated_bytes.ptr;
+// }
 
 pub const StartupData = c.StartupData;
 

--- a/src/v8.zig
+++ b/src/v8.zig
@@ -3233,12 +3233,12 @@ pub const RemoteObject = struct {
     }
 };
 
-// /// Enables C to allocate using the given Zig allocator
-// pub export fn zigAlloc(self: *anyopaque, bytes: usize) callconv(.c) ?[*]u8 {
-//     const allocator: *std.mem.Allocator = @ptrCast(@alignCast(self));
-//     const allocated_bytes = allocator.alloc(u8, bytes) catch return null;
-//     return allocated_bytes.ptr;
-// }
+/// Enables C to allocate using the given Zig allocator
+pub export fn zigAlloc(self: *anyopaque, bytes: usize) callconv(.c) ?[*]u8 {
+    const allocator: *std.mem.Allocator = @ptrCast(@alignCast(self));
+    const allocated_bytes = allocator.alloc(u8, bytes) catch return null;
+    return allocated_bytes.ptr;
+}
 
 pub const StartupData = c.StartupData;
 


### PR DESCRIPTION
Removes all the Zig code, except for exposing the C library.

It also adds binding for v8::Global and fixes the Module and Context typedef.