### PR TITLE
Expose ResourceConstraints::ConfigureDefaultsFromHeapSize

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -303,6 +303,13 @@ void v8__Isolate__CreateParams__CONSTRUCT(v8::Isolate::CreateParams* buf) {
     new (buf) v8::Isolate::CreateParams();
 }
 
+void v8__ResourceConstraints__ConfigureDefaultsFromHeapSize(
+        v8::ResourceConstraints* self,
+        size_t initial_heap_size_in_bytes,
+        size_t maximum_heap_size_in_bytes) {
+    self->ConfigureDefaultsFromHeapSize(initial_heap_size_in_bytes, maximum_heap_size_in_bytes);
+}
+
 const v8::Value* v8__Isolate__ThrowException(
         v8::Isolate* isolate,
         const v8::Value& exception) {

--- a/src/binding.h
+++ b/src/binding.h
@@ -302,6 +302,11 @@ typedef struct ResourceConstraints {
     uint32_t* stack_limit_;
 } ResourceConstraints;
 
+void v8__ResourceConstraints__ConfigureDefaultsFromHeapSize(
+    ResourceConstraints* self,
+    usize initial_heap_size_in_bytes,
+    usize maximum_heap_size_in_bytes);
+
 typedef struct CreateParams {
     void* code_event_handler; // JitCodeEventHandler
     ResourceConstraints constraints;


### PR DESCRIPTION
Don't need it right now, but I was testing something with it, and figured we might as well add it.