### PR TITLE
Introduce a new FunctionTemplate__New__Config

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1409,6 +1409,25 @@ const v8::Value* v8__ReturnValue__Get(
 
 // FunctionTemplate
 
+typedef enum SideEffectType {
+    kSideEffectType_HasSideEffect = 0,
+    kSideEffectType_HasNoSideEffect = 1,
+    kSideEffectType_HasSideEffectToReceiver = 2,
+} SideEffectType;
+
+typedef enum ConstructorBehavior {
+    kConstructorBehavior_Allow = 0,
+    kConstructorBehavior_Throw = 1,
+} ConstructorBehavior;
+
+typedef struct v8__FunctionTemplateConfig {
+    v8::FunctionCallback callback;
+    const v8::Value* data;
+    int length;
+    ConstructorBehavior behavior;
+    SideEffectType side_effect_type;
+} v8__FunctionTemplateConfig;
+
 const v8::FunctionTemplate* v8__FunctionTemplate__New__DEFAULT(
         v8::Isolate* isolate) {
     return local_to_ptr(v8::FunctionTemplate::New(isolate));
@@ -1425,6 +1444,24 @@ const v8::FunctionTemplate* v8__FunctionTemplate__New__DEFAULT3(
         v8::FunctionCallback callback_or_null,
         const v8::Value& data) {
     return local_to_ptr(v8::FunctionTemplate::New(isolate, callback_or_null, ptr_to_local(&data)));
+}
+
+const v8::FunctionTemplate* v8__FunctionTemplate__New__Config(
+        v8::Isolate* isolate,
+        const v8__FunctionTemplateConfig* config) {
+    v8::SideEffectType side_effect = static_cast<v8::SideEffectType>(config->side_effect_type);
+    v8::ConstructorBehavior behavior = static_cast<v8::ConstructorBehavior>(config->behavior);
+    v8::Local<v8::Value> data = config->data ? ptr_to_local(config->data) : v8::Local<v8::Value>();
+
+    return local_to_ptr(v8::FunctionTemplate::New(
+        isolate,
+        config->callback,
+        data,
+        v8::Local<v8::Signature>(),  // signature - default
+        config->length,
+        behavior,
+        side_effect
+    ));
 }
 
 const v8::ObjectTemplate* v8__FunctionTemplate__InstanceTemplate(

--- a/src/binding.h
+++ b/src/binding.h
@@ -791,6 +791,26 @@ const Value* v8__ReturnValue__Get(
 
 // FunctionTemplate
 typedef void (*FunctionCallback)(const FunctionCallbackInfo*);
+
+typedef enum SideEffectType {
+    kSideEffectType_HasSideEffect = 0,
+    kSideEffectType_HasNoSideEffect = 1,
+    kSideEffectType_HasSideEffectToReceiver = 2,
+} SideEffectType;
+
+typedef enum ConstructorBehavior {
+    kConstructorBehavior_Allow = 0,
+    kConstructorBehavior_Throw = 1,
+} ConstructorBehavior;
+
+typedef struct v8__FunctionTemplateConfig {
+    FunctionCallback callback;
+    const Value* data;
+    int length;
+    ConstructorBehavior behavior;
+    SideEffectType side_effect_type;
+} v8__FunctionTemplateConfig;
+
 const FunctionTemplate* v8__FunctionTemplate__New__DEFAULT(
     Isolate* isolate);
 const FunctionTemplate* v8__FunctionTemplate__New__DEFAULT2(
@@ -800,6 +820,9 @@ const FunctionTemplate* v8__FunctionTemplate__New__DEFAULT3(
     Isolate* isolate,
     FunctionCallback callback_or_null,
     const Value* data);
+const FunctionTemplate* v8__FunctionTemplate__New__Config(
+    Isolate* isolate,
+    const v8__FunctionTemplateConfig* config);
 const ObjectTemplate* v8__FunctionTemplate__InstanceTemplate(
     const FunctionTemplate* self);
 const ObjectTemplate* v8__FunctionTemplate__PrototypeTemplate(


### PR DESCRIPTION
FunctionTemplate's constructor takes like 9 optional parameters. The current binding exposes these as v8__FunctionTemplate__New__DEFAULT[2,3]{0,1}. Not particularly scalable.

This adds a `v8__FunctionTemplateConfig` which can be passed to a new constructor: v8__FunctionTemplate__New__Config. This allows us to set the length (which we should be doing) and the side effect (which we can do in a few cases).

I'd like to remove the current ones, but in 2 steps. First merge this one and update the code. Then at some point in the future we can remove the old ones.