### PR TITLE
Expose Object::GetAlignedPointerFromInternalField

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1335,6 +1335,12 @@ void v8__Object__SetAlignedPointerInInternalField(
     ptr_to_local(self)->SetAlignedPointerInInternalField(idx, ptr);
 }
 
+void * v8__Object__GetAlignedPointerFromInternalField(
+        const v8::Object* self,
+        int idx) {
+    return ptr_to_local(self)->GetAlignedPointerFromInternalField(idx);
+}
+
 // FunctionCallbackInfo
 
 v8::Isolate* v8__FunctionCallbackInfo__GetIsolate(

--- a/src/binding.h
+++ b/src/binding.h
@@ -668,6 +668,9 @@ void v8__Object__SetAlignedPointerInInternalField(
     const Object* self,
     int idx,
     void* ptr);
+void* v8__Object__GetAlignedPointerFromInternalField(
+    const Object* self,
+    int idx);
 
 // Exception
 const Value* v8__Exception__Error(const String* message);


### PR DESCRIPTION
We have `SetAlignedPointerInInternalField` already, but not the getter (which makes the setter not very useful).