### PR TITLE
Expose ContextConfig, MicrotaskQueue and AlignedEmbedderData

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -423,6 +423,39 @@ void v8__Isolate__EnqueueMicrotaskFunc(v8::Isolate* self, const v8::Function* fu
     self->EnqueueMicrotask(ptr_to_local(function));
 }
 
+// MicrotaskQueue
+
+v8::MicrotaskQueue* v8__MicrotaskQueue__New(
+        v8::Isolate* isolate,
+        v8::MicrotasksPolicy policy) {
+    return v8::MicrotaskQueue::New(isolate, policy).release();
+}
+
+void v8__MicrotaskQueue__DELETE(v8::MicrotaskQueue* self) {
+    delete self;
+}
+
+void v8__MicrotaskQueue__PerformCheckpoint(
+        v8::MicrotaskQueue* self,
+        v8::Isolate* isolate) {
+    self->PerformCheckpoint(isolate);
+}
+
+void v8__MicrotaskQueue__EnqueueMicrotask(
+        v8::MicrotaskQueue* self,
+        v8::Isolate* isolate,
+        v8::MicrotaskCallback callback,
+        void* data) {
+    self->EnqueueMicrotask(isolate, callback, data);
+}
+
+void v8__MicrotaskQueue__EnqueueMicrotaskFunc(
+    v8::MicrotaskQueue* self,
+    v8::Isolate* isolate,
+    const v8::Function* function) {
+    self->EnqueueMicrotask(isolate, ptr_to_local(function));
+}
+
 const v8::Data* v8__Isolate__GetDataFromSnapshotOnce(v8::Isolate *self, size_t idx) {
     v8::MaybeLocal<v8::Data> maybe = self->GetDataFromSnapshotOnce<v8::Data>(idx);
     if (maybe.IsEmpty()) {
@@ -517,12 +550,33 @@ void v8__HandleScope__DESTRUCT(v8::HandleScope* scope) { scope->~HandleScope(); 
 
 // Context
 
+typedef struct v8__ContextConfig {
+    const v8::ObjectTemplate* global_template;
+    const v8::Value* global_object;
+    v8::MicrotaskQueue* microtask_queue;
+} v8__ContextConfig;
+
 v8::Context* v8__Context__New(
         v8::Isolate* isolate,
         const v8::ObjectTemplate* global_tmpl,
         const v8::Value* global_obj) {
     return local_to_ptr(
         v8::Context::New(isolate, nullptr, ptr_to_maybe_local(global_tmpl), ptr_to_maybe_local(global_obj))
+    );
+}
+
+v8::Context* v8__Context__New__Config(
+        v8::Isolate* isolate,
+        const v8__ContextConfig* config) {
+    return local_to_ptr(
+        v8::Context::New(
+            isolate,
+            nullptr,
+            ptr_to_maybe_local(config->global_template),
+            ptr_to_maybe_local(config->global_object),
+            v8::DeserializeInternalFieldsCallback(),
+            config->microtask_queue
+        )
     );
 }
 
@@ -558,6 +612,19 @@ void v8__Context__SetEmbedderData(
         int idx,
         const v8::Value& val) {
     ptr_to_local(&self)->SetEmbedderData(idx, ptr_to_local(&val));
+}
+
+void * v8__Context__GetAlignedPointerFromEmbedderData(
+        const v8::Context* self,
+        int idx) {
+    return ptr_to_local(self)->GetAlignedPointerFromEmbedderData(idx);
+}
+
+void v8__Context__SetAlignedPointerInEmbedderData(
+        const v8::Context* self,
+        int idx,
+        void* ptr) {
+    ptr_to_local(self)->SetAlignedPointerInEmbedderData(idx, ptr);
 }
 
 int v8__Context__DebugContextId(const v8::Context& self) {

--- a/src/binding.h
+++ b/src/binding.h
@@ -15,6 +15,7 @@ typedef struct FunctionTemplate FunctionTemplate;
 typedef struct Message Message;
 typedef struct Data Context;
 typedef struct Data Private;
+typedef struct MicrotaskQueue MicrotaskQueue;
 // Internally, all Value types have a base InternalAddress struct.
 typedef uintptr_t InternalAddress;
 // Super type.
@@ -212,6 +213,14 @@ const char* v8__V8__GetVersion();
 // Microtask
 typedef enum MicrotasksPolicy { kExplicit, kScoped, kAuto } MicrotasksPolicy;
 
+// MicrotaskQueue
+MicrotaskQueue* v8__MicrotaskQueue__New(Isolate* isolate, MicrotasksPolicy policy);
+void v8__MicrotaskQueue__DELETE(MicrotaskQueue* queue);
+void v8__MicrotaskQueue__PerformCheckpoint(MicrotaskQueue* queue, Isolate* isolate);
+typedef void (*MicrotaskCallback)(void* data);
+void v8__MicrotaskQueue__EnqueueMicrotask(MicrotaskQueue* queue, Isolate* isolate, MicrotaskCallback callback, void* data);
+void v8__MicrotaskQueue__EnqueueMicrotaskFunc(MicrotaskQueue* queue, Isolate* isolate, const Function* function);
+
 // Snapshot
 typedef enum FunctionCodeHandling { kClear, kKeep } FunctionCodeHandling;
 
@@ -289,7 +298,6 @@ void v8__Isolate__GetHeapStatistics(
 usize v8__HeapStatistics__SIZEOF();
 void* v8__Isolate__GetData(Isolate* self, int idx);
 void v8__Isolate__SetData(Isolate* self, int idx, void* val);
-typedef void (*MicrotaskCallback)(void* data);
 void v8__Isolate__EnqueueMicrotask(Isolate* self, MicrotaskCallback callback, void* data);
 void v8__Isolate__EnqueueMicrotaskFunc(Isolate* self, const Function* function);
 const Data* v8__Isolate__GetDataFromSnapshotOnce(const Isolate *self, size_t idx);
@@ -437,7 +445,15 @@ bool v8__StackFrame__IsUserJavaScript(const StackFrame* self);
 
 // Context
 typedef struct ObjectTemplate ObjectTemplate;
+
+typedef struct v8__ContextConfig {
+    const ObjectTemplate* global_template;
+    const Value* global_object;
+    MicrotaskQueue* microtask_queue;
+} v8__ContextConfig;
+
 Context* v8__Context__New(Isolate* isolate, const ObjectTemplate* global_tmpl, const Value* global_obj);
+Context* v8__Context__New__Config(Isolate* isolate, const v8__ContextConfig* config);
 Context* v8__Context__FromSnapshot(Isolate*, size_t);
 void v8__Context__Enter(const Context* context);
 void v8__Context__Exit(const Context* context);
@@ -450,6 +466,14 @@ void v8__Context__SetEmbedderData(
     const Context* self,
     int idx,
     const Value* val);
+void* v8__Context__GetAlignedPointerFromEmbedderData(
+    const Context* self,
+    int idx);
+void v8__Context__SetAlignedPointerInEmbedderData(
+    const Context* self,
+    int idx,
+    void* ptr);
+
 int v8__Context__DebugContextId(const Context* self);
 const Data* v8__Context__GetDataFromSnapshotOnce(const Context *self, size_t idx);
 


### PR DESCRIPTION
Add a ContextConfig and a Context__New__Config. This follows the similar pattern and purpose as https://github.com/lightpanda-io/zig-v8-fork/pull/147 - better API for optional C++ parameters.

The parameter that we're interested in this case is giving each context its own MicrotaskQueue. So rather than being per-isolate, MicrotaskQueues are per- Context.

Also add Get/Set AlignedEmbedderData to Context. This is like https://github.com/lightpanda-io/zig-v8-fork/pull/149 (on object) as a better (and correct) way to store external data (a Zig pointer) in a v8 Object without having it be meaningful to the v8 GC.