### PR TITLE
Expose v8::Context::SetSecurityToken

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -643,6 +643,19 @@ const v8::Data* v8__Context__GetDataFromSnapshotOnce(v8::Context *self, size_t i
     return local_to_ptr(maybe.ToLocalChecked());
 }
 
+void v8__Context__SetSecurityToken(
+        const v8::Context& self,
+        const v8::Value& val) {
+    ptr_to_local(&self)->SetSecurityToken(ptr_to_local(&val));
+}
+void v8__Context__UseDefaultSecurityToken(
+    const v8::Context& self) {
+    ptr_to_local(&self)->UseDefaultSecurityToken();
+}
+const v8::Value* v8__Context__GetSecurityToken(
+        const v8::Context& self) {
+    return local_to_ptr(ptr_to_local(&self)->GetSecurityToken());
+}
 // ScriptOrigin
 
 void v8__ScriptOrigin__CONSTRUCT(

--- a/src/binding.h
+++ b/src/binding.h
@@ -478,6 +478,10 @@ void v8__Context__SetAlignedPointerInEmbedderData(
 int v8__Context__DebugContextId(const Context* self);
 const Data* v8__Context__GetDataFromSnapshotOnce(const Context *self, size_t idx);
 
+void v8__Context__SetSecurityToken(const Context* self, const Value* val);
+void v8__Context__UseDefaultSecurityToken(const Context* self);
+const Value* v8__Context__GetSecurityToken(const Context* self);
+
 // Boolean
 const Boolean* v8__Boolean__New(
     Isolate* isolate,


### PR DESCRIPTION
As well as the other Security Token helpers. Needed for better frame support.