### PR TITLE
Migrate from ninja to siso

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -26,6 +26,9 @@ const GnArgs = struct {
         var args: std.ArrayList(u8) = .empty;
         const gpa = b.allocator;
 
+        // Use modern siso instead of outdated ninja to speed up the build.
+        try args.appendSlice(gpa, "use_siso=true\n");
+
         // official builds depend on pgo
         try args.appendSlice(gpa, "is_official_build=false\n");
         try args.appendSlice(gpa, b.fmt("is_debug={}\n", .{self.is_debug}));
@@ -398,7 +401,7 @@ fn buildV8(
     gn_run.step.dependOn(&bootstrapped_v8.step);
 
     const ninja_run = b.addSystemCommand(&.{
-        getDepotToolExePath(b, depot_tools_dir, "ninja"),
+        getDepotToolExePath(b, depot_tools_dir, "autoninja"),
         "-C",
         out_dir,
         "c_v8",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .fingerprint = 0x10be7411eb47d7c5,
     .dependencies = .{
         .depot_tools = .{
-            .url = "git+https://github.com/rust-skia/depot_tools#8efa575d754b8703d99b0f827528e45aeaa167aa",
-            .hash = "N-V-__8AANgeXQAuTDjDItrtITfVslPonFWB-h3Az2C0-2AM",
+            .url = "https://chromium.googlesource.com/chromium/tools/depot_tools.git/+archive/4ce8ba39a3488397a2d1494f167020f21de502f3.tar.gz",
+            .hash = "N-V-__8AABDOXwDW4TLrTiydikRCN2ym9hJI1GKGR09ZLBvY",
         },
     },
 }


### PR DESCRIPTION
First, it updates depot_tools (we were using a four-year-old version) to upstream instead of a fork. This is what V8 relies on.

Second, it switches the build from ninja to [siso](https://chromium.googlesource.com/build/+/refs/heads/main/siso/README.md). Ninja has been deprecated since last fall.

Building with siso is on average 30-50% faster due to better IO utilization. Also, siso uses a persistent cache, so rebuilding v8 with different parameters (for example, with and without tsan) should be almost instant with a warmed-up cache.