### PR TITLE
Update deps in CI, move common scripts to reusable action

### DIFF
--- a/.github/workflows/_prebuild-v8.yml
+++ b/.github/workflows/_prebuild-v8.yml
@@ -1,0 +1,91 @@
+name: prebuild v8
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        type: string
+      target:
+        type: string
+      build_type:
+        type: string
+      lp_cache:
+        type: string
+        default: '.lp-cache'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Parse target
+        shell: bash
+        run: |
+          echo "OS=$(echo "${{ inputs.target }}" | cut -d- -f2)" >> "$GITHUB_ENV"
+          echo "ARCH=$(echo "${{ inputs.target }}" | cut -d- -f1)" >> "$GITHUB_ENV"
+
+      - uses: mlugg/setup-zig@v2.2.1
+        with:
+          cache-key: ${{ inputs.target }}
+
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Read V8 version from build.zig
+        shell: bash
+        run: echo "V8_REVISION=$(sed -n 's/^const V8_VERSION.*"\(.*\)".*/\1/p' build.zig)" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-python@v6.2.0
+        if: contains(inputs.target, 'macos') || contains(inputs.target, 'ios')
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies (Linux x86_64)
+        if: contains(inputs.target, 'linux')
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yq libglib2.0-dev lld
+
+      - name: Install dependencies (Linux aarch64)
+        if: contains(inputs.target, 'aarch64-linux')
+        shell: bash
+        run: |
+            wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh
+            sudo ./llvm.sh 21
+            sudo ln -nsf /usr/lib/llvm-21/lib/clang/21/lib/linux/libclang_rt.builtins-aarch64.a /usr/lib/llvm-21/lib/clang/21/lib/linux/libclang_rt.builtins.a
+            sudo ln -nsf /usr/lib/llvm-21/lib/clang/21/lib/linux/ /usr/lib/llvm-21/lib/clang/21/lib/aarch64-unknown-linux-gnu
+
+      - shell: bash
+        run: zig env
+
+      - name: Build V8
+        shell: bash
+        run: |
+          if [ "${{ inputs.build_type }}" = "debug" ]; then
+            zig build -Dtarget="${{ inputs.target }}" -Doptimize=Debug -Dis_tsan=true -Dv8_enable_sandbox=true build-v8
+          else
+            zig build -Dtarget="${{ inputs.target }}" -Doptimize=ReleaseSafe build-v8
+          fi
+
+      - name: Find v8 library
+        shell: bash
+        run: |
+          DST="${{ env.ARCH }}"
+          if [ "${{ inputs.build_type }}" = "debug" ]; then
+            DST="${DST}_debug"
+          fi
+          if [ "${{ env.OS }}" = "ios" ]; then
+            DST="simulator_${DST}"
+          fi
+          mv "${{ inputs.lp_cache }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/${{ inputs.build_type }}/obj/zig/libc_v8.a" "libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_$DST.a"
+
+      - name: Upload the build
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          artifacts: libc_v8_*.a

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -2,205 +2,53 @@ name: build-release
 
 on:
   push:
-    tags:
-      - "**"
+    tags: ["**"]
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 permissions:
   contents: write
 
-env:
-  ZIG_VERSION: 0.15.1
-  V8_REVISION: 14.0.365.4
-  LP_CACHE: ".lp-cache"
-
 jobs:
   build-x86_64-linux:
-    env:
-      OS: linux
-      ARCH: x86_64
-
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: mlugg/setup-zig@v2.0.5
-        with:
-          version: ${{ env.ZIG_VERSION }}
-          cache-key: ${{ env.ZIG_VERSION }}-${{ env.OS }}-${{ env.ARCH }}
-
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      - run: zig env
-
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -yq libglib2.0-dev
-
-      - run: zig build -Doptimize=ReleaseSafe build-v8
-      - run: mv ${{ env.LP_CACHE }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/release/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
-
-      - name: Upload the build
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          artifacts: libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
+    uses: ./.github/workflows/_prebuild-v8.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-linux
+      build_type: release
 
   build-x86_64-linux-debug:
-    env:
-      OS: linux
-      ARCH: x86_64
-
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: mlugg/setup-zig@v2.0.5
-        with:
-          version: ${{ env.ZIG_VERSION }}
-          cache-key: ${{ env.ZIG_VERSION }}-${{ env.OS }}-${{ env.ARCH }}
-
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      - run: zig env
-
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -yq libglib2.0-dev
-
-      - run: zig build -Doptimize=Debug -Dis_tsan=true -Dv8_enable_sandbox=true build-v8
-      - run: mv ${{ env.LP_CACHE }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/debug/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}_debug.a
-
-      - name: Upload the build
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          artifacts: libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}_debug.a
-
-  build-aarch64-macos:
-    env:
-      OS: macos
-      ARCH: aarch64
-
-    runs-on: macos-latest
-    steps:
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: ${{ env.ZIG_VERSION }}
-          cache-key: ${{ env.ZIG_VERSION }}-${{ env.OS }}-${{ env.ARCH }}
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      - run: zig build -Doptimize=ReleaseSafe build-v8
-      - run: mv ${{ env.LP_CACHE }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/release/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
-
-      - name: Upload the build
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          artifacts: libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
+    uses: ./.github/workflows/_prebuild-v8.yml
+    with:
+      runner: ubuntu-24.04
+      target: x86_64-linux
+      build_type: debug
 
   build-arm64-linux:
-    env:
-      OS: linux
-      ARCH: aarch64
+    uses: ./.github/workflows/_prebuild-v8.yml
+    with:
+      runner: ubuntu-24.04-arm
+      target: aarch64-linux
+      build_type: release
 
-    runs-on: ubuntu-22.04-arm
-    steps:
-      - uses: mlugg/setup-zig@v2
-        with:
-          cache-key: ${{ env.ZIG_VERSION }}-${{ env.OS }}-${{ env.ARCH }}
-          version: ${{ env.ZIG_VERSION }}
-
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      - run: |
-          sudo apt-get update
-          sudo apt-get install -yq libglib2.0-dev lld
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 21
-          sudo ln -nsf /usr/lib/llvm-21/lib/clang/21/lib/linux/libclang_rt.builtins-aarch64.a /usr/lib/llvm-21/lib/clang/21/lib/linux/libclang_rt.builtins.a && \
-          sudo ln -nsf /usr/lib/llvm-21/lib/clang/21/lib/linux/ /usr/lib/llvm-21/lib/clang/21/lib/aarch64-unknown-linux-gnu
-
-      - run: zig build -Doptimize=ReleaseSafe build-v8
-      - run: mv ${{ env.LP_CACHE }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/release/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
-
-      - name: Upload the build
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          artifacts: libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
+  build-aarch64-macos:
+    uses: ./.github/workflows/_prebuild-v8.yml
+    with:
+      runner: macos-26
+      target: aarch64-macos
+      build_type: release
 
   build-x86_64-macos:
-    env:
-      OS: macos
-      ARCH: x86_64
-
-    runs-on: macos-15-large
-    steps:
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: ${{ env.ZIG_VERSION }}
-          cache-key: ${{ env.ZIG_VERSION }}-${{ env.OS }}-${{ env.ARCH }}
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      - run: zig build -Doptimize=ReleaseSafe build-v8
-      - run: mv ${{ env.LP_CACHE }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/release/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
-
-      - name: Upload the build
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          artifacts: libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.a
+    uses: ./.github/workflows/_prebuild-v8.yml
+    with:
+      runner: macos-26-intel
+      target: x86_64-macos
+      build_type: release
 
   build-aarch64-ios:
-    env:
-      OS: ios
-      ARCH: aarch64
-      TARGET_ENVIRONMENT: simulator
-
-    runs-on: macos-latest
-    steps:
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: ${{ env.ZIG_VERSION }}
-          cache-key: ${{ env.ZIG_VERSION }}-${{ env.OS }}-${{ env.ARCH }}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      - run: zig build -Doptimize=ReleaseSafe build-v8
-      - run: mv ${{ env.LP_CACHE }}/v8-${{ env.V8_REVISION }}/out/macos/release/obj/zig/libc_v8.a libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.TARGET_ENVIRONMENT }}_${{ env.ARCH }}.a
-
-      - name: Upload the build
-        uses: ncipollo/release-action@v1
-        with:
-          allowUpdates: true
-          artifacts: libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.TARGET_ENVIRONMENT }}_${{ env.ARCH }}.a
+    uses: ./.github/workflows/_prebuild-v8.yml
+    with:
+      runner: macos-26
+      target: aarch64-ios-simulator
+      build_type: release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This dockerfile is used to build v8.
-ARG ZIG_DOCKER_VERSION=0.15.1
+ARG ZIG_DOCKER_VERSION=0.15.2
 FROM ghcr.io/lightpanda-io/zig:${ZIG_DOCKER_VERSION} as build
 
 ARG OS=linux

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Builds V8 from official source and provides C bindings and a Zig API. This would
 V8 is the JS/WASM runtime that powers Google Chrome and Microsoft Edge.
 
 ## System Requirements
-- Zig compiler (0.15.1). Clone and build https://github.com/ziglang/zig.
+- Zig compiler (0.15.2). Clone and build https://github.com/ziglang/zig.
 - Python 3 (2.7 seems to work as well)
 - unzip (`apt install unzip`)
 - rsync (`apt install rsync`)

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,12 +1,20 @@
 .{
     .name = .v8,
-    .paths = .{""},
     .version = "0.0.0",
-    .fingerprint = 0x10be7411eb47d7c5,
+    .fingerprint = 0x10be7411eb47d7c5, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .depot_tools = .{
             .url = "https://chromium.googlesource.com/chromium/tools/depot_tools.git/+archive/4ce8ba39a3488397a2d1494f167020f21de502f3.tar.gz",
             .hash = "N-V-__8AABDOXwDW4TLrTiydikRCN2ym9hJI1GKGR09ZLBvY",
         },
+    },
+    .paths = .{
+        "src/",
+        "build-tools/",
+        "README",
+        "LICENSE",
+        "build.zig",
+        "build.zig.zon",
     },
 }


### PR DESCRIPTION
There's a problem with running the build on CI in main. It looks like a GH bug (the build task simply doesn't start and hangs), but I've found through trial and error that updating the images and compiler resolves the issue. No idea how it works.

At the same time, I moved the common code into a function in CI and updated the Zig version to match the one in the main repository.

We should also update to v8 (`14.0.365.4` was released in August, 7 months ago), but some Isolate APIs have been updated, and we need to investigate that separately.

Successful CI build: https://github.com/lightpanda-io/zig-v8-fork/actions/runs/22981327814