### PR TITLE
provide a build_telemetry.cfg

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -400,6 +400,22 @@ fn buildV8(
     addDepotToolsToPath(gn_run, depot_tools_dir);
     gn_run.step.dependOn(&bootstrapped_v8.step);
 
+    const build_telemetry_config_content =
+        \\ {
+        \\   "user": "lightpanda",
+        \\   "status": "opt-out",
+        \\   "countdown": 20,
+        \\   "version": 1
+        \\ }
+    ;
+
+    const write_telemetry_config = b.addSystemCommand(&.{ "sh", "-c" });
+    write_telemetry_config.addArg(b.fmt("echo '{s}' > {s}", .{
+        build_telemetry_config_content,
+        getDepotToolExePath(b, depot_tools_dir, "build_telemetry.cfg"),
+    }));
+    write_telemetry_config.step.dependOn(&gn_run.step);
+
     const ninja_run = b.addSystemCommand(&.{
         getDepotToolExePath(b, depot_tools_dir, "autoninja"),
         "-C",
@@ -408,7 +424,7 @@ fn buildV8(
     });
     ninja_run.setCwd(v8_dir_lazy_path);
     addDepotToolsToPath(ninja_run, depot_tools_dir);
-    ninja_run.step.dependOn(&gn_run.step);
+    ninja_run.step.dependOn(&write_telemetry_config.step);
 
     const wf = b.addWriteFiles();
     wf.step.dependOn(&ninja_run.step);

--- a/build.zig
+++ b/build.zig
@@ -188,12 +188,28 @@ fn bootstrapDepotTools(b: *std.Build, depot_tools_dir: []const u8) !*std.Build.S
     copy_depot_tools.addDirectoryArg(depot_tools.path(""));
     copy_depot_tools.addArg(depot_tools_dir);
 
+    const build_telemetry_config_content =
+        \\ {
+        \\   "user": "lightpanda",
+        \\   "status": "opt-out",
+        \\   "countdown": 20,
+        \\   "version": 1
+        \\ }
+    ;
+
+    const write_telemetry_config = b.addSystemCommand(&.{ "sh", "-c" });
+    write_telemetry_config.addArg(b.fmt("echo '{s}' > {s}/build_telemetry.cfg", .{
+        build_telemetry_config_content,
+        depot_tools_dir,
+    }));
+    write_telemetry_config.step.dependOn(&copy_depot_tools.step);
+
     const ensure_bootstrap = b.addSystemCommand(&.{
         getDepotToolExePath(b, depot_tools_dir, "ensure_bootstrap"),
     });
     ensure_bootstrap.setCwd(.{ .cwd_relative = depot_tools_dir });
     addDepotToolsToPath(ensure_bootstrap, depot_tools_dir);
-    ensure_bootstrap.step.dependOn(&copy_depot_tools.step);
+    ensure_bootstrap.step.dependOn(&write_telemetry_config.step);
 
     const create_marker = b.addSystemCommand(&.{ "touch", marker_file });
     create_marker.step.dependOn(&ensure_bootstrap.step);
@@ -400,22 +416,6 @@ fn buildV8(
     addDepotToolsToPath(gn_run, depot_tools_dir);
     gn_run.step.dependOn(&bootstrapped_v8.step);
 
-    const build_telemetry_config_content =
-        \\ {
-        \\   "user": "lightpanda",
-        \\   "status": "opt-out",
-        \\   "countdown": 20,
-        \\   "version": 1
-        \\ }
-    ;
-
-    const write_telemetry_config = b.addSystemCommand(&.{ "sh", "-c" });
-    write_telemetry_config.addArg(b.fmt("echo '{s}' > {s}", .{
-        build_telemetry_config_content,
-        getDepotToolExePath(b, depot_tools_dir, "build_telemetry.cfg"),
-    }));
-    write_telemetry_config.step.dependOn(&gn_run.step);
-
     const ninja_run = b.addSystemCommand(&.{
         getDepotToolExePath(b, depot_tools_dir, "autoninja"),
         "-C",
@@ -424,7 +424,7 @@ fn buildV8(
     });
     ninja_run.setCwd(v8_dir_lazy_path);
     addDepotToolsToPath(ninja_run, depot_tools_dir);
-    ninja_run.step.dependOn(&write_telemetry_config.step);
+    ninja_run.step.dependOn(&gn_run.step);
 
     const wf = b.addWriteFiles();
     wf.step.dependOn(&ninja_run.step);


### PR DESCRIPTION
Without this config, the build tries to download a ./cipd_client. This seems to provide some authentication features. But the download is given a 3 second timeout. If it fails to download in those 3 seconds, things work, but it will delay the build for 3 seconds for every time it tries to load this (which appears to be 3 times per build, so a 9 second delay). By providing the build_telemetry_cfg, the build no longer tries to download the cipd_client.

This all happens in build_telemtry.py.