### PR TITLE
ci: fix v8 artifact path in release build

### DIFF
--- a/.github/workflows/_prebuild-v8.yml
+++ b/.github/workflows/_prebuild-v8.yml
@@ -81,7 +81,8 @@ jobs:
           if [ "${{ env.OS }}" = "ios" ]; then
             DST="simulator_${DST}"
           fi
-          mv "${{ inputs.lp_cache }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/${{ inputs.build_type }}/obj/zig/libc_v8.a" "libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_$DST.a"
+          V8_LIB_PATH=(${{ inputs.lp_cache }}/v8-${{ env.V8_REVISION }}/out/${{ env.OS }}/${{ inputs.build_type }}_*/obj/zig/libc_v8.a)
+          mv "${V8_LIB_PATH[0]}" "libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_$DST.a"
 
       - name: Upload the build
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
The output directory for V8 builds now contains a hash of the GN args. Update the prebuild workflow to use a wildcard pattern to locate the libc_v8.a library correctly during the copy step.