### PR TITLE
Change the arraybuffer internal field count to 0

### DIFF
--- a/build-tools/.gn
+++ b/build-tools/.gn
@@ -63,9 +63,8 @@ default_args = {
   # fixed addresses.
   v8_typed_array_max_size_in_heap = 0
 
-  # Historically these always had 2 slots. Keep for compat.
-  v8_array_buffer_internal_field_count = 2
-  v8_array_buffer_view_internal_field_count = 2
+  v8_array_buffer_internal_field_count = 0
+  v8_array_buffer_view_internal_field_count = 0
 
   # Enabling the shared read-only heap comes with a restriction that all
   # isolates running at the same time must be created from the same snapshot.


### PR DESCRIPTION
This was inherited form the Rusty build. We don't use the internal fields for ArrayBuffers. This potentially explains the error seen here: https://github.com/lightpanda-io/browser/pull/2050

But, I'm running into it with WebSocket implemenation, where send() takes a string, TypedArray, ArrayBuffer or Blob and the ArrayBuffer having an internal field is unexpected / causing issues.