### PR TITLE
Set Zig build version in action

### DIFF
--- a/.github/workflows/_prebuild-v8.yml
+++ b/.github/workflows/_prebuild-v8.yml
@@ -28,6 +28,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2.2.1
         with:
+          version: 0.15.2
           cache-key: ${{ inputs.target }}
 
       - uses: actions/checkout@v6.0.2


### PR DESCRIPTION
Necessary now that the default version is 0.16