### PR TITLE
docs: update build commands to prepare-v8 (#127)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ADD . /src/
 WORKDIR /src
 
 RUN zig build
-RUN zig build get-v8
+RUN zig build prepare-v8
 RUN zig build -Doptimize=ReleaseSafe build-v8
 
 RUN mv v8/out/linux/release/obj/zig/libc_v8.a /src/libc_v8.a

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ if you come across this error:<br />
 Compiling v8 will take 20+ minutes.
 
 ```sh
-zig build get-v8
+zig build prepare-v8
 zig build build-v8
 ```
 


### PR DESCRIPTION
Fixes #127.

## What changed

Replaced two stale references to `zig build get-v8` with `zig build prepare-v8`:

- README.md "Build" section
- Dockerfile build stage (after the initial `zig build`)

## Why this matters

The `get-v8` step no longer exists in build.zig. Running it against the current source produces:

```
error: no step named 'get-v8'
```

The current step is defined in build.zig:109 as:

```zig
const prepare_step = b.step("prepare-v8", "Prepare V8 source code");
```

So new contributors following the README, or anyone rebuilding the Dockerfile, hit a hard stop on the very first build instruction. Updating the docs to match the actual step names removes that block.

## Verification

After the change, `grep -rn "get-v8" --include="*.md" --include=Dockerfile --include="*.zig"` returns no matches.