### PR TITLE
inspector: avoid v8::String allocation in fromStringView

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -2440,14 +2440,35 @@ static inline v8_inspector::StringView toStringView(const std::string &str) {
 }
 
 static inline std::string fromStringView(v8::Isolate* isolate, const v8_inspector::StringView stringView) {
-  int length = static_cast<int>(stringView.length());
-  v8::Local<v8::String> message = (
-        stringView.is8Bit()
-          ? v8::String::NewFromOneByte(isolate, stringView.characters8(), v8::NewStringType::kNormal, length)
-          : v8::String::NewFromTwoByte(isolate, stringView.characters16(), v8::NewStringType::kNormal, length)
-      ).ToLocalChecked();
-  v8::String::Utf8Value result(isolate, message);
-  return *result;
+  // Convert the inspector StringView to UTF-8 *without* allocating a
+  // v8::String. The previous implementation round-tripped through
+  // v8::String::NewFromOneByte / NewFromTwoByte (just to use Utf8Value
+  // for the conversion), which calls into V8's heap allocator. That is
+  // forbidden during certain V8 internal phases -- in particular,
+  // weak callbacks during garbage collection, where V8's
+  // PromiseHandlerTracker can invoke EvaluateCallback::sendFailure,
+  // which lands in Channel::sendResponse, which calls this helper.
+  // Allocating in that context trips AllowHeapAllocation::IsAllowed()
+  // and aborts the process in debug builds (in release builds the
+  // allocation is undefined behavior).
+  //
+  // The 8-bit case can be a direct memcpy; the 16-bit case uses
+  // v8_inspector::UTF16ToUTF8 (a pure host-side helper that doesn't
+  // touch the V8 heap) -- the same path allocString() uses.
+  //
+  // The `isolate` parameter is preserved for API compatibility but is
+  // no longer needed.
+  (void)isolate;
+  if (stringView.is8Bit()) {
+    return std::string(
+      reinterpret_cast<const char*>(stringView.characters8()),
+      stringView.length()
+    );
+  }
+  return v8_inspector::UTF16ToUTF8(
+    reinterpret_cast<const char16_t*>(stringView.characters16()),
+    stringView.length()
+  );
 }
 
 /// Allocates a string as utf8 on the allocator without \0 terminator, for use in Zig.


### PR DESCRIPTION
## Summary

Stop calling V8's heap allocator from `fromStringView()`. The previous implementation went through `v8::String::NewFromOneByte` / `NewFromTwoByte` just to reuse `v8::String::Utf8Value` for the UTF-16 -> UTF-8 conversion. That allocation is into V8's managed heap, which is forbidden during certain V8 internal phases -- most notably weak callbacks during garbage collection.

## Failure path

```
v8::internal::HeapAllocator::AllocateRaw  (debug check fails)
  v8::String::NewFromOneByte
    fromStringView                       (this helper)
      v8_inspector__Channel__IMPL::sendResponse
        v8_crdtp::DomainDispatcher::sendResponse
          v8_inspector::EvaluateCallback::sendFailure
            v8_inspector::PromiseHandlerTracker::sendFailure
              v8_inspector::PromiseHandlerTracker::discard
                v8::internal::GlobalHandles::InvokeFirstPassWeakCallbacks
                  v8::internal::Heap::PerformGarbageCollection
```

V8 invokes inspector callbacks (`PromiseHandlerTracker::discard`, which sends a failure response for a stale `Runtime.evaluate`) from inside GC's first-pass weak-callbacks phase. The response delivery routes through `Channel::sendResponse` and into this helper; the `v8::String::NewFromOneByte` call then trips `AllowHeapAllocation::IsAllowed()` in `heap-allocator-inl.h:79`, aborting the process in debug builds with:

```
# Fatal error in ../../../src/heap/heap-allocator-inl.h, line 79
# Debug check failed: AllowHeapAllocation::IsAllowed().
```

In release builds the assertion is compiled out, but allocating during weak callbacks is still undefined behavior -- it can corrupt V8's GC walk.

## Fix

The conversion doesn't actually need V8 at all -- it's just bytes in, UTF-8 bytes out. Use the same approach `allocString()` already uses (the call site immediately below this one in the same file): direct `std::string` construction for the 8-bit case, `v8_inspector::UTF16ToUTF8` for the 16-bit case. `v8_inspector::UTF16ToUTF8` is a pure host-side helper that doesn't touch the V8 heap.

The `isolate` parameter is kept for API compatibility (still callable by the `sendResponse` / `sendNotification` wrappers below) but is no longer referenced.

```cpp
static inline std::string fromStringView(v8::Isolate* isolate, const v8_inspector::StringView stringView) {
  (void)isolate;
  if (stringView.is8Bit()) {
    return std::string(
      reinterpret_cast<const char*>(stringView.characters8()),
      stringView.length()
    );
  }
  return v8_inspector::UTF16ToUTF8(
    reinterpret_cast<const char16_t*>(stringView.characters16()),
    stringView.length()
  );
}
```

## Verification

Reproducer comes from `lightpanda-io/browser` (the only consumer of this binding I'm aware of with active inspector traffic): a `puppeteer-core` script driving a `lightpanda serve` against an iframe-heavy page that runs Web Workers. The Allbirds product page (`https://www.allbirds.com/products/mens-wool-runners`) instantiates ~8 web-pixel sandbox workers; the inspector keeps `Runtime.evaluate` callbacks alive past the worker / page lifetime, GC eventually fires `PromiseHandlerTracker::discard`, and the resulting `sendFailure` lands in `fromStringView` -> `NewFromOneByte` -> abort.

Before this change: stress loop running the puppeteer repro 25 times back-to-back against a single Lightpanda server reliably aborts with the fatal above (typically within 5--15 iterations).

After this change: same loop runs to completion, 25/25 successful page loads, server stays alive, no V8 fatals in the log.

Built and tested via Lightpanda's `build.zig.zon` swapped to a `path = "../zig-v8-fork"` checkout of this branch.

## Related

* lightpanda-io/browser#2407 -- the issue that motivated this fix; full reproduction recipe and stack traces.
* lightpanda-io/browser#2398 -- worker-reentrancy fix in Lightpanda; required to even *reach* this V8 inspector path under stress (without it, an earlier UAF crashes Lightpanda before the inspector callback fires during GC). Independent of this change.

## Notes

* The `isolate` parameter is intentionally kept rather than removed, since `fromStringView` is `static inline` in this file but the call sites pass `this->isolate` and removing the parameter would be a larger churn.
* Behavior is unchanged for valid inputs. The implementation now also avoids `ToLocalChecked()`, which previously would have aborted on V8 allocation failure -- now propagates as a regular `std::string` allocation failure (consistent with the rest of the file).
