### PR TITLE
Expose Isolate::RequestInterrupt

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -397,6 +397,10 @@ void v8__Isolate__CancelTerminateExecution(v8::Isolate* self) {
     self->CancelTerminateExecution();
 }
 
+void v8__Isolate__RequestInterrupt(v8::Isolate* self, v8::InterruptCallback callback, void* data) {
+    self->RequestInterrupt(callback, data);
+}
+
 void v8__Isolate__LowMemoryNotification(v8::Isolate* self) {
     self->LowMemoryNotification();
 }

--- a/src/binding.h
+++ b/src/binding.h
@@ -285,6 +285,8 @@ void v8__Isolate__SetCaptureStackTraceForUncaughtExceptions(
 void v8__Isolate__TerminateExecution(Isolate* self);
 bool v8__Isolate__IsExecutionTerminating(Isolate* self);
 void v8__Isolate__CancelTerminateExecution(Isolate* self);
+typedef void (*InterruptCallback)(Isolate* isolate, void* data);
+void v8__Isolate__RequestInterrupt(Isolate* self, InterruptCallback callback, void* data);
 void v8__Isolate__LowMemoryNotification(Isolate* self);
 typedef enum MemoryPressureLevel {
     kNone = 0,


### PR DESCRIPTION
This is for a safer terminate flow on client disconnect.