### PR TITLE
Expose external allocated memory adjustment

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -415,6 +415,12 @@ void v8__Isolate__MemoryPressureNotification(v8::Isolate* self, v8::MemoryPressu
     self->MemoryPressureNotification(level);
 }
 
+int64_t v8__Isolate__AdjustAmountOfExternalAllocatedMemory(
+        v8::Isolate* self,
+        int64_t change_in_bytes) {
+    return self->AdjustAmountOfExternalAllocatedMemory(change_in_bytes);
+}
+
 void v8__Isolate__GetHeapStatistics(
         v8::Isolate* self,
         v8::HeapStatistics* stats) {

--- a/src/binding.h
+++ b/src/binding.h
@@ -298,6 +298,9 @@ typedef enum MemoryPressureLevel {
     kCritical = 2
 } MemoryPressureLevel;
 void v8__Isolate__MemoryPressureNotification(Isolate* self, MemoryPressureLevel level);
+int64_t v8__Isolate__AdjustAmountOfExternalAllocatedMemory(
+    Isolate* self,
+    int64_t change_in_bytes);
 typedef struct HeapStatistics {
     size_t total_heap_size;
     size_t total_heap_size_executable;


### PR DESCRIPTION
## Summary

Expose `v8::Isolate::AdjustAmountOfExternalAllocatedMemory` through the C binding so Zig embedders can report native allocations that are retained by JavaScript wrappers.

The signed return and argument types match V8's API.

Required by lightpanda-io/browser#3027.
