### PR TITLE
build: always build V8 library-safe

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -29,7 +29,6 @@ const GnArgs = struct {
     is_debug: bool,
     symbol_level: u8,
     v8_enable_sandbox: bool,
-    for_shared_library: bool,
 
     fn asString(self: GnArgs, b: *std.Build, target: std.Build.ResolvedTarget) ![]const u8 {
         const tag = target.result.os.tag;
@@ -49,17 +48,15 @@ const GnArgs = struct {
         try args.appendSlice(gpa, b.fmt("is_tsan={}\n", .{self.is_tsan}));
         try args.appendSlice(gpa, b.fmt("v8_enable_sandbox={}\n", .{self.v8_enable_sandbox}));
 
-        if (self.for_shared_library) {
-            // Defines V8_TLS_USED_IN_LIBRARY: the isolate thread-locals get a
-            // TLS model that is legal inside a shared library (the default
-            // local-exec model is exe-only).
-            try args.appendSlice(gpa, "v8_monolithic=true\n");
-            try args.appendSlice(gpa, "v8_monolithic_for_shared_library=true\n");
-            // No malloc interposition: inside a shared library the shim binds
-            // locally, so libc-allocated memory freed through it crashes (and
-            // a library must not hijack the host's malloc anyway).
-            try args.appendSlice(gpa, "use_allocator_shim=false\n");
-        }
+        // V8_TLS_USED_IN_LIBRARY gives the isolate thread-locals a TLS model
+        // that is legal inside a .so (the default local-exec model is
+        // exe-only); executables relax back to local-exec at link time.
+        try args.appendSlice(gpa, "v8_monolithic=true\n");
+        try args.appendSlice(gpa, "v8_monolithic_for_shared_library=true\n");
+        // No malloc interposition: inside a version-scripted .so the shim
+        // binds locally, so libc-allocated memory freed through it crashes —
+        // and a library must not hijack the host's malloc anyway.
+        try args.appendSlice(gpa, "use_allocator_shim=false\n");
 
         switch (tag) {
             .ios => {
@@ -91,7 +88,6 @@ pub fn build(b: *std.Build) !void {
         .is_asan = b.option(bool, "is_asan", "Address sanitizer") orelse false,
         .is_tsan = b.option(bool, "is_tsan", "Thread sanitizer") orelse false,
         .v8_enable_sandbox = b.option(bool, "v8_enable_sandbox", "V8 lightable sandbox") orelse false,
-        .for_shared_library = b.option(bool, "for_shared_library", "Build V8 with a TLS model usable inside a shared library") orelse false,
     };
 
     var build_opts = b.addOptions();
@@ -155,14 +151,7 @@ pub fn build(b: *std.Build) !void {
     v8_module.addImport("binding", binding_module);
     v8_module.addImport("default_exports", build_opts.createModule());
 
-    // Consumers that link the archive per final-link artifact (so it doesn't
-    // get embedded into their own static libraries) opt out of the module
-    // attach and take the path from the named LazyPath instead.
-    b.addNamedLazyPath("libc_v8", built_v8.libc_v8_path);
-    const attach_v8_archive = b.option(bool, "attach_v8_archive", "Attach libc_v8.a to the v8 module (default true)") orelse true;
-    if (attach_v8_archive) {
-        v8_module.addObjectFile(built_v8.libc_v8_path);
-    }
+    v8_module.addObjectFile(built_v8.libc_v8_path);
 
     switch (target.result.os.tag) {
         .macos => {


### PR DESCRIPTION
Drop the for_shared_library and attach_v8_archive options: every build now gets the shared-library-legal TLS model (executables relax it back to local-exec at link time) and no malloc shim, and libc_v8.a is always attached to the module. One archive serves executables and shared libraries alike.