### PR TITLE
Add prebuild linux x86-64 .so

### DIFF
--- a/.github/workflows/_prebuild-v8.yml
+++ b/.github/workflows/_prebuild-v8.yml
@@ -78,6 +78,28 @@ jobs:
             zig build -Dtarget="${{ inputs.target }}" -Doptimize=ReleaseSafe build-v8
           fi
 
+      # zig's self-hosted linker doesn't work when we statically link V8. I'm
+      # not sure what the issue is (I believe there are multiple issues). But
+      # It does work if we dynamically link it. Claude sais it has something
+      # to do with CREL reloations which Zig can't do but the bundled lld here
+      # handles fine. Maybe as a separate issue (or maybe it's the same) there's
+      # also problems caused by the allocator shim. Whatever the case, this step
+      # exists to create a dynamic library that can be used with browser's
+      # -Ddev_fast builds.
+      - name: Link shared v8 library
+        if: inputs.target == 'x86_64-linux' && inputs.build_type == 'release'
+        shell: bash
+        run: |
+          V8_DIR=${{ inputs.lp_cache }}/v8-${{ env.V8_REVISION }}
+          V8_LIB_PATH=($V8_DIR/out/${{ env.OS }}/${{ inputs.build_type }}_*/obj/zig/libc_v8.a)
+          "$V8_DIR/third_party/llvm-build/Release+Asserts/bin/clang++" \
+            -shared -fuse-ld=lld -nostdlib++ \
+            -o "libc_v8_${{ env.V8_REVISION }}_${{ env.OS }}_${{ env.ARCH }}.so" \
+            -Wl,-soname,libc_v8.so \
+            -Wl,--version-script=build-tools/v8_exports.map \
+            -Wl,--whole-archive "${V8_LIB_PATH[0]}" -Wl,--no-whole-archive \
+            -lpthread -ldl -lm
+
       - name: Find v8 library
         shell: bash
         run: |
@@ -96,7 +118,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
-          artifacts: libc_v8_*.a
+          artifacts: libc_v8_*.a,libc_v8_*.so
           # Semver convention: hyphenated tags (v0.4.8-slim.0) are prereleases,
           # so experimental builds never become the "latest" release.
           prerelease: ${{ contains(github.ref_name, '-') }}

--- a/.github/workflows/_prebuild-v8.yml
+++ b/.github/workflows/_prebuild-v8.yml
@@ -80,8 +80,8 @@ jobs:
 
       # zig's self-hosted linker doesn't work when we statically link V8. I'm
       # not sure what the issue is (I believe there are multiple issues). But
-      # It does work if we dynamically link it. Claude sais it has something
-      # to do with CREL reloations which Zig can't do but the bundled lld here
+      # It does work if we dynamically link it. Claude says it has something
+      # to do with CREL relocations which Zig can't do but the bundled lld here
       # handles fine. Maybe as a separate issue (or maybe it's the same) there's
       # also problems caused by the allocator shim. Whatever the case, this step
       # exists to create a dynamic library that can be used with browser's

--- a/build-tools/BUILD.gn
+++ b/build-tools/BUILD.gn
@@ -1,12 +1,6 @@
 # Copyright 2018-2019 the Deno authors. All rights reserved. MIT license.
 # Based on https://github.com/denoland/rusty_v8/blob/main/BUILD.gn
 
-declare_args() {
-  # Build the bindings for inclusion in libc_v8.so rather than libc_v8.a.
-  # Linux dev builds only; see -Dshared_v8 in build.zig.
-  c_v8_shared = false
-}
-
 static_library("c_v8") {
   complete_static_lib = true
 
@@ -30,14 +24,10 @@ config("c_v8_config") {
     "//:toolchain",
     "//:features",
   ]
-  cflags = []
-
-  if (c_v8_shared) {
-    # Chromium compiles with -fvisibility=hidden, which leaves every binding
-    # symbol STV_HIDDEN and therefore unexportable from a shared library. This
-    # config only applies to binding.cpp, not to the V8 deps.
-    cflags += [ "-fvisibility=default" ]
-  }
+  # This config only applies to binding.cpp, not to the V8 deps. It has no
+  # impact when we link statically. Having it always on means we can relink
+  # libc_v8.a into an .so (where it does matter).
+  cflags = [ "-fvisibility=default" ]
 
   # We need these directories in the search path to be able to include some
   # internal V8 headers.

--- a/build.zig
+++ b/build.zig
@@ -24,7 +24,6 @@ fn addDepotToolsToPath(step: *std.Build.Step.Run, depot_tools_dir: []const u8) v
 }
 
 const GnArgs = struct {
-    shared: bool,
     is_asan: bool,
     is_tsan: bool,
     is_debug: bool,
@@ -74,12 +73,6 @@ const GnArgs = struct {
             else => {},
         }
 
-        if (self.shared) {
-            // Chromium's -fvisibility=hidden would otherwise leave every binding
-            // symbol STV_HIDDEN, so the .so would export nothing.
-            try args.appendSlice(gpa, "c_v8_shared=true\n");
-        }
-
         return gpa.dupe(u8, args.items);
     }
 };
@@ -92,7 +85,6 @@ pub fn build(b: *std.Build) !void {
     const shared_v8 = b.option(bool, "shared_v8", "Link V8 as a shared library") orelse false;
 
     const gn_args = GnArgs{
-        .shared = shared_v8,
         .is_debug = optimize == .Debug,
         .symbol_level = b.option(u8, "symbol_level", "Symbol level") orelse if (optimize == .Debug) 1 else 0,
         .is_asan = b.option(bool, "is_asan", "Address sanitizer") orelse false,
@@ -112,16 +104,37 @@ pub fn build(b: *std.Build) !void {
         try std.Io.Dir.cwd().createDirPath(io, cache_root);
     };
 
-    const prebuilt_v8_path = b.option([]const u8, "prebuilt_v8_path", "Path to prebuilt libc_v8.a");
+    const prebuilt_v8_path = b.option([]const u8, "prebuilt_v8_path", "Path to a prebuilt libc_v8.a or libc_v8.so");
 
     const v8_dir = b.fmt("{s}/v8-{s}", .{ cache_root, V8_VERSION });
     const depot_tools_dir = b.fmt("{s}/depot_tools-{s}", .{ cache_root, V8_VERSION });
 
-    const built_v8 = if (prebuilt_v8_path) |path| blk: {
-        // Use prebuilt_v8 if available.
+    const built_v8 = if (prebuilt_v8_path) |raw_path| blk: {
+        // Use prebuilt_v8 if available. A .so is linked shared (the exe
+        // records DT_NEEDED "libc_v8.so", so the file must keep that name);
+        // anything else is an archive and links statically. The path is
+        // resolved to an absolute one so the rpath baked into the exe does
+        // not depend on the directory it is run from.
+        const is_shared_lib = std.mem.endsWith(u8, raw_path, ".so");
+        if (is_shared_lib and !std.mem.eql(u8, std.fs.path.basename(raw_path), "libc_v8.so")) {
+            std.debug.print("prebuilt_v8_path: a shared V8 must be named libc_v8.so (got {s})\n", .{raw_path});
+            return error.PrebuiltV8BadName;
+        }
+        if (shared_v8 and !is_shared_lib) {
+            std.debug.print("-Dshared_v8 needs a libc_v8.so, but prebuilt_v8_path points at an archive ({s})\n", .{raw_path});
+            return error.PrebuiltV8NotShared;
+        }
+        const path = std.Io.Dir.cwd().realPathFileAlloc(io, raw_path, b.allocator) catch |err| {
+            std.debug.print("prebuilt_v8_path: cannot resolve {s}: {t}\n", .{ raw_path, err });
+            return err;
+        };
         break :blk BuiltV8{
             .step = b.step("prebuilt_v8", "Use prebuilt v8"),
             .libc_v8_path = .{ .cwd_relative = path },
+            .shared_dir = if (is_shared_lib)
+                .{ .cwd_relative = std.fs.path.dirname(path) orelse "." }
+            else
+                null,
         };
     } else blk: {
         const bootstrapped_depot_tools = try bootstrapDepotTools(b, depot_tools_dir);
@@ -521,6 +534,7 @@ fn buildV8(
             "-nostdlib++",
             "-o",
             libc_v8_so_path,
+            "-Wl,-soname,libc_v8.so",
             b.fmt("-Wl,--version-script={s}", .{b.pathFromRoot("build-tools/v8_exports.map")}),
             "-Wl,--whole-archive",
             libc_v8_path,


### PR DESCRIPTION
Reworks the build a little so that the .a and .so can re-use the same artifacts so hopefully the .so builds fast after the .a. Essentially, -fvisibility=default is always enabled (it does nothing when statically linked, so no harm).

This is to better support https://github.com/lightpanda-io/browser/pull/3167