### PR TITLE
CI: Fix arm build

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,7 +28,7 @@ jobs:
   build-arm64-linux:
     uses: ./.github/workflows/_prebuild-v8.yml
     with:
-      runner: ubuntu-22.04-arm
+      runner: ubuntu-24.04-arm
       target: aarch64-linux
       build_type: release
 


### PR DESCRIPTION
apt.llvm.org no longer publishes an LLVM 23 repo for 22.04. This bumps the arm runner to ubuntu-24.04-arm.

See:
https://github.com/lightpanda-io/zig-v8-fork/actions/runs/31648075532/job/94286149823#step:9:207