### PR TITLE
Export ICU bidi, shaping and line-break entry points from the shared build

### DIFF
--- a/build-tools/v8_exports.map
+++ b/build-tools/v8_exports.map
@@ -11,5 +11,10 @@
     v8_inspector__*;
     std__*;
     allocString;
+    /* ICU: bidi, Arabic shaping, line breaking (screenshot renderer). */
+    ubidi_*;
+    ubrk_*;
+    u_shapeArabic_*;
+    u_charMirror_*;
   local: *;
 };


### PR DESCRIPTION
Adds `ubidi_*`, `ubrk_*`, `u_shapeArabic_*` and `u_charMirror_*` to `build-tools/v8_exports.map`.

**Why.** The browser's upcoming pure-Zig screenshot renderer (branch `screenshot-z2d`, stacked on lightpanda-io/browser#3231) does bidi reordering, Arabic shaping and UAX #14 line breaking with the ICU that V8 already bundles. The static archive exposes those symbols today (`nm libc_v8_14.9.207.35_linux_x86_64.a` lists `ubidi_setPara_77`, `u_shapeArabic_77`, `ubrk_open_77`, … and the embedded `icudt77_dat`), so release builds link fine. The shared dev build hides them behind the version script, so `dev_fast` builds can't link the renderer until a prebuilt ships with this change — which is why this goes first and independently.

**Scope.** Globs are deliberately narrow (`u_shapeArabic_*`, `u_charMirror_*` rather than `u_*`), and all four are ICU-prefixed, so nothing here can interpose libc the way the allocator shim did; the `local: *` default still applies to everything else. The `_*` suffix tracks ICU's major-version symbol renaming.

**Not verified locally**: I checked the symbols exist in the static archive but haven't rebuilt the `.so` with the new map (no local V8 build). A prebuilt from the next tag is the real test; the browser side then just needs `nm -D libc_v8.so | grep ubidi_open` to show the symbol.